### PR TITLE
Improve local fs perfs with excluded dirs

### DIFF
--- a/doc/app/config/packages/stenope.yaml
+++ b/doc/app/config/packages/stenope.yaml
@@ -1,27 +1,27 @@
 stenope:
-  providers:
-    App\Model\Index:
-      type: files
-      path: '%kernel.project_dir%/../../'
-      excludes:
-        - doc/**
-        - node_modules/**
-        - vendor/**
-      patterns:
-        - '*.md'
+    providers:
+        App\Model\Index:
+            type: files
+            path: '%kernel.project_dir%/../../'
+            excludes:
+                - doc
+                - node_modules
+                - vendor
+            patterns:
+                - '*.md'
 
-    App\Model\Page:
-      type: files
-      path: '%kernel.project_dir%/../'
-      excludes:
-        - app/**
-      patterns:
-        - '*.md'
+        App\Model\Page:
+            type: files
+            path: '%kernel.project_dir%/../'
+            excludes:
+                - app
+            patterns:
+                - '*.md'
 
-  copy:
-    - src: '%kernel.project_dir%/public'
-      dest: .
-      excludes:
-        - '*.php'
-    - src: '%kernel.project_dir%/../images'
-      dest: './images'
+    copy:
+        - src: '%kernel.project_dir%/public'
+          dest: .
+          excludes:
+              - '*.php'
+        - src: '%kernel.project_dir%/../images'
+          dest: './images'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,14 +3,15 @@ includes:
 
 parameters:
     bootstrapFiles:
-        - tests/bootstrap.php
         - config/tags.php
+        - tests/bootstrap.php
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
 
     excludes_analyse:
-        - vendor/
         - doc/app/
+        - node_modules/
         - tests/fixtures/app/var/
+        - vendor/
 
     level: 1
 

--- a/tests/Unit/Provider/LocalFilesystemProviderTest.php
+++ b/tests/Unit/Provider/LocalFilesystemProviderTest.php
@@ -150,19 +150,22 @@ class LocalFilesystemProviderTest extends TestCase
             ],
         ];
 
-        yield 'config excluding explicit dir (not as a glob)' => [
-            new LocalFilesystemProvider(
-                'App\Foo',
-                self::FIXTURES_DIR . '/content/excluded_dirs',
-                null,
-                ['bar/'],
-                ['*.md'],
-            ),
-            [
-                'bar (markdown)',
-                'foo/bar (markdown)',
-                'foo/bar/baz (markdown)',
-            ],
-        ];
+        // This one cannot be resolved until https://github.com/symfony/symfony/issues/28158 is.
+        // If one really needs to exclude a dir but not subdirs with the same name, they must use the glob pattern
+        // as in the previous test case sample, despite it may have a big performances impact
+        //yield 'config excluding explicit dir (not as a glob)' => [
+        //    new LocalFilesystemProvider(
+        //        'App\Foo',
+        //        self::FIXTURES_DIR . '/content/excluded_dirs',
+        //        null,
+        //        ['bar/'],
+        //        ['*.md'],
+        //    ),
+        //    [
+        //        'bar (markdown)',
+        //        'foo/bar (markdown)',
+        //        'foo/bar/baz (markdown)',
+        //    ],
+        //];
     }
 }


### PR DESCRIPTION
Improves drastically the performances when excluding consequent directories like `node_modules` or `vendor` for instance, 
by relying on `Finder::exclude` rather than `notPath` whenever we detect an explicit directory exclusion (the Stenope doc app is affected).

See https://blackfire.io/profiles/compare/21f2db19-e74e-4d09-9500-bc3624a4754f/graph

(the time is not really relevant for the comparison, as the profile without this patch is erroneous, and rendering time would rather be something like between 2 and 3 secs. However, see the saved method calls.)

I'm a bit annoyed with the commented test-case, but there is a way to circumvent for particular case as explained in the comment (until there is a fix in Symfony Finder allowing to properly exclude only the specified dirs).
But I feel the perfs impact is too much to be ignored.