### PR TITLE
Always use the current Stenope version to build docs

### DIFF
--- a/doc/app/composer.json
+++ b/doc/app/composer.json
@@ -16,7 +16,7 @@
         "symfony/twig-bundle": "^5.1",
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/yaml": "5.1.*",
-        "stenope/stenope": "0.x-dev",
+        "stenope/stenope": "dev-master",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"
     },
@@ -76,8 +76,8 @@
     },
     "repositories": {
         "stenope/stenope": {
-            "type": "vcs",
-            "url": "https://github.com/StenopePHP/Stenope.git"
+            "type": "path",
+            "url": "../../"
         }
     }
 }

--- a/doc/app/composer.lock
+++ b/doc/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfdb58af48e100d4ecb85c9e8b1248a7",
+    "content-hash": "fff7832afbe26de7fec2d0468fb913e2",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -727,16 +727,10 @@
         {
             "name": "stenope/stenope",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/StenopePHP/Stenope.git",
-                "reference": "945c85a089fc3640c04ec95589947243d665820d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/StenopePHP/Stenope/zipball/945c85a089fc3640c04ec95589947243d665820d",
-                "reference": "945c85a089fc3640c04ec95589947243d665820d",
-                "shasum": ""
+                "type": "path",
+                "url": "../..",
+                "reference": "b77849adbcb6426293f005f5d3e8ba5915e66f46"
             },
             "require": {
                 "erusev/parsedown": "^1.7.4",
@@ -764,6 +758,7 @@
             "require-dev": {
                 "ekino/phpstan-banned-code": "^0.3.1",
                 "friendsofphp/php-cs-fixer": "^2.16",
+                "phpspec/prophecy-phpunit": "^2.0",
                 "phpstan/phpstan": "^0.12.32",
                 "symfony/browser-kit": "^5.1",
                 "symfony/framework-bundle": "^5.1",
@@ -771,7 +766,6 @@
                 "symfony/twig-bridge": "^5.1",
                 "symfony/twig-bundle": "^5.1"
             },
-            "default-branch": true,
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
@@ -811,11 +805,9 @@
                 "static",
                 "symfony"
             ],
-            "support": {
-                "source": "https://github.com/StenopePHP/Stenope/tree/master",
-                "issues": "https://github.com/StenopePHP/Stenope/issues"
-            },
-            "time": "2020-11-27T10:29:47+00:00"
+            "transport-options": {
+                "relative": true
+            }
         },
         {
             "name": "symfony/asset",


### PR DESCRIPTION
using Composer path repositories

![Capture d’écran 2020-12-02 à 09 05 56](https://user-images.githubusercontent.com/2211145/100845486-9cbb2980-347d-11eb-92c5-1ccc1e995e11.png)