### PR TITLE
[Doc] Use PHP 8 attributes for examples

### DIFF
--- a/doc/route-options.md
+++ b/doc/route-options.md
@@ -8,13 +8,11 @@ You may want to exclude some routes from the static generated version of your si
 In order to ignore such routes during the build, set the `stenope.ignore` option to `true`:
 
 ```php
-/**
-* @Route("foo", name="foo", options={
-*     "stenope": {
-*         "ignore": true,
-*     },
-* })
-*/
+#[Route('foo', name: 'foo', options: [
+    'stenope' => [
+        'ignore' => true,
+    ],
+])]
 public function fooAction() { /* ... */ }
 ```
 
@@ -24,12 +22,10 @@ If you need to exclude some routes from the generated sitemap,
 set the `stenope.sitemap` route option to `false`:
 
 ```php
-/**
-* @Route("foo", name="foo", options={
-*     "stenope": {
-*         "sitemap": false,
-*     },
-* })
-*/
+#[Route('foo', name: 'foo', options: [
+    'stenope' => [
+        'sitemap' => false,
+    ],
+])]
 public function fooAction() { /* ... */ }
 ```

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -9,18 +9,16 @@ For the builder to understand such urls should be handled differently,
 explicitly provide either the `format` option in your route definition:
 
 ```php
-/**
-* @Route("foo.pdf", name="foo_pdf", format="pdf")
-*/
+#[Route('foo.pdf', name: 'foo', format: 'pdf')]
 public function renderAsPdf() { /* ... */ }
 ```
 
 or the `_format` request attribute / route default:
 
 ```php
-/**
-* @Route("foo.pdf", name="foo_pdf", defaults={ "_format": "pdf" })
-*/
+#[Route('foo.pdf', name: 'foo', defaults: [
+    '_format' => 'pdf',
+])]
 public function renderAsPdf(Request $request)
 {
    // or directly through request attributes:


### PR DESCRIPTION
as those are the future and are way more easy to write multiline since it's pure PHP syntax and not mixed with docblocks.