### PR TITLE
Add a --ignore-content-not-found flag to build command

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -83,6 +83,12 @@ class BuildCommand extends Command
                 InputOption::VALUE_NONE,
                 'Don\'t expose the public directory'
             )
+            ->addOption(
+                'ignore-content-not-found',
+                null,
+                InputOption::VALUE_NONE,
+                'Ignore content not found errors'
+            )
         ;
     }
 
@@ -129,14 +135,19 @@ class BuildCommand extends Command
 
         $sitemap = $input->getOption('no-sitemap');
         $expose = $input->getOption('no-expose');
+        $ignoreContentNotFoundErrors = $input->getOption('ignore-content-not-found');
 
         if ($input->isInteractive() && $output->isDecorated() && $output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
             // In interactive, ansi compatible envs with normal verbosity, use a progress bar
-            iterator_to_array($progressIterator = new BuildProgressIterator($output, $this->builder->iterate(!$sitemap, !$expose)));
+            iterator_to_array($progressIterator = new BuildProgressIterator($output, $this->builder->iterate(
+                !$sitemap,
+                !$expose,
+                $ignoreContentNotFoundErrors,
+            )));
             $count = \count($progressIterator);
         } else {
             // Otherwise, let the user controls shown information in logs through verbosity
-            $count = $this->builder->build(!$sitemap, !$expose);
+            $count = $this->builder->build(!$sitemap, !$expose, $ignoreContentNotFoundErrors);
             $io->newLine();
         }
 

--- a/src/ContentManager.php
+++ b/src/ContentManager.php
@@ -10,6 +10,7 @@ namespace Stenope\Bundle;
 
 use Stenope\Bundle\Behaviour\ContentManagerAwareInterface;
 use Stenope\Bundle\Behaviour\ProcessorInterface;
+use Stenope\Bundle\Exception\ContentNotFoundException;
 use Stenope\Bundle\Provider\ContentProviderInterface;
 use Stenope\Bundle\Provider\ReversibleContentProviderInterface;
 use Stenope\Bundle\ReverseContent\Context;
@@ -142,7 +143,7 @@ class ContentManager
             }
         }
 
-        throw new \RuntimeException(sprintf('Content not found for type "%s" and id "%s".', $type, $id));
+        throw new ContentNotFoundException($type, $id);
     }
 
     public function reverseContent(Context $context): ?Content

--- a/src/Exception/ContentNotFoundException.php
+++ b/src/Exception/ContentNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Exception;
+
+class ContentNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+{
+    public function __construct(string $type, string $id)
+    {
+        parent::__construct(sprintf('Content not found for type "%s" and id "%s".', $type, $id));
+    }
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Exception;
+
+/**
+ * Marker interface for all the meaningful exceptions from the Stenope package
+ */
+interface ExceptionInterface
+{
+}


### PR DESCRIPTION
Use-case:

![Capture d’écran 2021-02-03 à 17 28 22](https://user-images.githubusercontent.com/2211145/106777396-40bf7d80-6645-11eb-8180-37ed19193b20.png)

I want to be able to build the static site in a "Preview" job, even if there are missing content pages detected, so I can still deploy a preview of the current PR. This new flag allows it.
However, in another "CI / Tests" job, I do not add this flag, so I still have a failing check on my PR to inspect and be aware there is probably an issue.

![Capture d’écran 2021-02-03 à 17 10 45](https://user-images.githubusercontent.com/2211145/106775415-63509700-6643-11eb-80fd-cf1147597ba1.png)

![Capture d’écran 2021-02-03 à 17 16 05](https://user-images.githubusercontent.com/2211145/106775613-91ce7200-6643-11eb-99ee-c1b08a35f195.png)


poke @benji07 @maximecolin