### PR TITLE
Expand assets URLs processing to links

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -22,12 +22,12 @@ use Stenope\Bundle\EventListener\SitemapListener;
 use Stenope\Bundle\Highlighter\Prism;
 use Stenope\Bundle\Highlighter\Pygments;
 use Stenope\Bundle\HttpKernel\Controller\ArgumentResolver\ContentArgumentResolver;
+use Stenope\Bundle\Processor\AssetsProcessor;
 use Stenope\Bundle\Processor\CodeHighlightProcessor;
 use Stenope\Bundle\Processor\ExtractTitleFromHtmlContentProcessor;
 use Stenope\Bundle\Processor\HtmlAnchorProcessor;
 use Stenope\Bundle\Processor\HtmlExternalLinksProcessor;
 use Stenope\Bundle\Processor\HtmlIdProcessor;
-use Stenope\Bundle\Processor\HtmlImageProcessor;
 use Stenope\Bundle\Processor\LastModifiedProcessor;
 use Stenope\Bundle\Processor\ResolveContentLinksProcessor;
 use Stenope\Bundle\Processor\SlugProcessor;
@@ -36,7 +36,7 @@ use Stenope\Bundle\Provider\Factory\LocalFilesystemProviderFactory;
 use Stenope\Bundle\Routing\ContentUrlResolver;
 use Stenope\Bundle\Routing\UrlGenerator;
 use Stenope\Bundle\Serializer\Normalizer\SkippingInstantiatedObjectDenormalizer;
-use Stenope\Bundle\Service\ImageAssetUtils;
+use Stenope\Bundle\Service\AssetUtils;
 use Stenope\Bundle\Service\Parsedown;
 use Stenope\Bundle\Twig\ContentExtension;
 use Stenope\Bundle\Twig\ContentRuntime;
@@ -146,7 +146,7 @@ return static function (ContainerConfigurator $container): void {
             ->tag('twig.runtime')
 
         // Assets
-        ->set(ImageAssetUtils::class)
+        ->set(AssetUtils::class)
             ->args(['$assets' => service(Packages::class)])
     ;
 
@@ -161,8 +161,8 @@ return static function (ContainerConfigurator $container): void {
         ->set(HtmlAnchorProcessor::class)
         ->set(HtmlExternalLinksProcessor::class)
         ->set(ExtractTitleFromHtmlContentProcessor::class)
-        ->set(HtmlImageProcessor::class)->args(['$imageAssetUtils' => service(ImageAssetUtils::class)])
         ->set(CodeHighlightProcessor::class)->args(['$highlighter' => service(Prism::class)])
         ->set(ResolveContentLinksProcessor::class)->args(['$resolver' => service(ContentUrlResolver::class)])
+        ->set(AssetsProcessor::class)->args(['$assetUtils' => service(AssetUtils::class)])
     ;
 };

--- a/src/Processor/AssetsProcessor.php
+++ b/src/Processor/AssetsProcessor.php
@@ -10,17 +10,20 @@ namespace Stenope\Bundle\Processor;
 
 use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Content;
-use Stenope\Bundle\Service\ImageAssetUtils;
+use Stenope\Bundle\Service\AssetUtils;
 use Symfony\Component\DomCrawler\Crawler;
 
-class HtmlImageProcessor implements ProcessorInterface
+/**
+ * Attempt to resolve local assets URLs using the Asset component for images and links.
+ */
+class AssetsProcessor implements ProcessorInterface
 {
-    private ImageAssetUtils $imageAssetUtils;
+    private AssetUtils $assetUtils;
     private string $property;
 
-    public function __construct(ImageAssetUtils $imageAssetUtils, string $property = 'content')
+    public function __construct(AssetUtils $assetUtils, string $property = 'content')
     {
-        $this->imageAssetUtils = $imageAssetUtils;
+        $this->assetUtils = $assetUtils;
         $this->property = $property;
     }
 
@@ -42,7 +45,11 @@ class HtmlImageProcessor implements ProcessorInterface
         $crawler = new Crawler($data[$this->property]);
 
         foreach ($crawler->filter('img') as $element) {
-            $element->setAttribute('src', $this->imageAssetUtils->getUrl($element->getAttribute('src')));
+            $element->setAttribute('src', $this->assetUtils->getUrl($element->getAttribute('src')));
+        }
+
+        foreach ($crawler->filter('a') as $element) {
+            $element->setAttribute('href', $this->assetUtils->getUrl($element->getAttribute('href')));
         }
 
         $data[$this->property] = $crawler->html();

--- a/src/Service/AssetUtils.php
+++ b/src/Service/AssetUtils.php
@@ -10,7 +10,7 @@ namespace Stenope\Bundle\Service;
 
 use Symfony\Component\Asset\Packages;
 
-class ImageAssetUtils
+class AssetUtils
 {
     private Packages $assets;
 
@@ -21,8 +21,8 @@ class ImageAssetUtils
 
     public function getUrl(string $url): string
     {
-        if (preg_match('#((https?:)?//)?(.+)$#', $url, $matches)) {
-            // Only process local images (ignoring urls starting by "http", "https" or "//").
+        if (preg_match('#^((\w+:)?//)?(.+)$#', $url, $matches)) {
+            // Only process local assets (ignoring urls starting by a scheme or "//").
             if (!$matches[1]) {
                 return $this->assets->getUrl($matches[3]);
             }


### PR DESCRIPTION
So we can properly link to local assets (with URLs resolved by the Asset component), like PDFs & other files.