### PR TITLE
Do ignore routes even if generated during build

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -34,6 +34,7 @@ use Stenope\Bundle\Processor\SlugProcessor;
 use Stenope\Bundle\Provider\Factory\ContentProviderFactory;
 use Stenope\Bundle\Provider\Factory\LocalFilesystemProviderFactory;
 use Stenope\Bundle\Routing\ContentUrlResolver;
+use Stenope\Bundle\Routing\RouteInfoCollection;
 use Stenope\Bundle\Routing\UrlGenerator;
 use Stenope\Bundle\Serializer\Normalizer\SkippingInstantiatedObjectDenormalizer;
 use Stenope\Bundle\Service\AssetUtils;
@@ -73,6 +74,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(Builder::class)->args([
             '$router' => service('router'),
+            '$routesInfo' => service(RouteInfoCollection::class),
             '$httpKernel' => service('kernel'),
             '$templating' => service('twig'),
             '$pageList' => service(PageList::class),
@@ -90,7 +92,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(Sitemap::class)
         ->set(SitemapListener::class)
             ->args([
-                '$router' => service('router'),
+                '$routesInfo' => service(RouteInfoCollection::class),
                 '$sitemap' => service(Sitemap::class),
             ])
             ->tag('kernel.event_subscriber')
@@ -124,9 +126,13 @@ return static function (ContainerConfigurator $container): void {
         ->set(UrlGenerator::class)
             ->decorate(UrlGeneratorInterface::class)
             ->args([
+                '$routesInfo' => service(RouteInfoCollection::class),
                 '$urlGenerator' => service(UrlGenerator::class . '.inner'),
                 '$pageList' => service(PageList::class),
             ])
+        ->set(RouteInfoCollection::class)->args([
+            '$router' => service('router'),
+        ])
         ->set(ContentUrlResolver::class)->args([
             '$router' => service('router'),
             '$routes' => 'The routes to resolve types, defined by the extension',

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -14,7 +14,7 @@ use Stenope\Bundle\Builder\PageList;
 use Stenope\Bundle\Builder\Sitemap;
 use Stenope\Bundle\Exception\ContentNotFoundException;
 use Stenope\Bundle\HttpFoundation\ContentRequest;
-use Stenope\Bundle\Routing\RouteInfo;
+use Stenope\Bundle\Routing\RouteInfoCollection;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -36,6 +36,7 @@ use Twig\Environment;
 class Builder
 {
     private RouterInterface $router;
+    private RouteInfoCollection $routesInfo;
     private HttpKernelInterface $httpKernel;
     private Environment $templating;
     private PageList $pageList;
@@ -52,6 +53,7 @@ class Builder
 
     public function __construct(
         RouterInterface $router,
+        RouteInfoCollection $routesInfo,
         HttpKernelInterface $httpKernel,
         Environment $templating,
         PageList $pageList,
@@ -62,6 +64,7 @@ class Builder
         ?Stopwatch $stopwatch = null
     ) {
         $this->router = $router;
+        $this->routesInfo = $routesInfo;
         $this->httpKernel = $httpKernel;
         $this->templating = $templating;
         $this->pageList = $pageList;
@@ -218,7 +221,7 @@ class Builder
         $this->stopwatch->openSection();
         $this->stopwatch->start('scan_routes');
 
-        $routes = RouteInfo::createFromRouteCollection($this->router->getRouteCollection());
+        $routes = $this->routesInfo;
 
         $this->logger->notice('Scanning {count} routes...', ['count' => \count($routes)]);
 

--- a/src/EventListener/SitemapListener.php
+++ b/src/EventListener/SitemapListener.php
@@ -9,23 +9,22 @@
 namespace Stenope\Bundle\EventListener;
 
 use Stenope\Bundle\Builder\Sitemap;
-use Stenope\Bundle\Routing\RouteInfo;
+use Stenope\Bundle\Routing\RouteInfoCollection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Map all routes into a Sitemap
  */
 class SitemapListener implements EventSubscriberInterface
 {
-    private array $routes;
+    private RouteInfoCollection $routesInfo;
     private Sitemap $sitemap;
 
-    public function __construct(RouterInterface $router, Sitemap $sitemap)
+    public function __construct(RouteInfoCollection $routesInfo, Sitemap $sitemap)
     {
-        $this->routes = RouteInfo::createFromRouteCollection($router->getRouteCollection());
+        $this->routesInfo = $routesInfo;
         $this->sitemap = $sitemap;
     }
 
@@ -38,7 +37,7 @@ class SitemapListener implements EventSubscriberInterface
             return;
         }
 
-        $route = $this->routes[$routeName];
+        $route = $this->routesInfo[$routeName];
 
         if ($route && $route->isMapped() && $request->attributes->get('_canonical')) {
             $this->sitemap->add(

--- a/src/Routing/RouteInfo.php
+++ b/src/Routing/RouteInfo.php
@@ -27,7 +27,7 @@ class RouteInfo
     }
 
     /**
-     * @return RouteInfo[]
+     * @return array<string,RouteInfo>
      */
     public static function createFromRouteCollection(RouteCollection $collection): array
     {

--- a/src/Routing/RouteInfoCollection.php
+++ b/src/Routing/RouteInfoCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Routing;
+
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @phpstan-implements IteratorAggregate<string,RouteInfo>
+ */
+class RouteInfoCollection implements \IteratorAggregate, \ArrayAccess, \Countable
+{
+    private RouterInterface $router;
+
+    /** @var array<string,RouteInfo>|null */
+    private ?array $routeInfos = null;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return array<string,RouteInfo>
+     */
+    private function getInfos(): array
+    {
+        if (!$this->routeInfos) {
+            $this->routeInfos = RouteInfo::createFromRouteCollection($this->router->getRouteCollection());
+        }
+
+        return $this->routeInfos;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->getInfos());
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->getInfos()[$offset]);
+    }
+
+    /**
+     * @return RouteInfo|null
+     */
+    public function offsetGet($offset)
+    {
+        return $this->getInfos()[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new \BadMethodCallException(sprintf('Unexpected call to "%s()"', __METHOD__));
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new \BadMethodCallException(sprintf('Unexpected call to "%s()"', __METHOD__));
+    }
+
+    public function count()
+    {
+        return \count($this->getInfos());
+    }
+}

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -19,18 +19,22 @@ class UrlGenerator implements UrlGeneratorInterface
 {
     private UrlGeneratorInterface $urlGenerator;
     private PageList $pageList;
+    private RouteInfoCollection $routesInfo;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, PageList $pageList)
+    public function __construct(RouteInfoCollection $routesInfo, UrlGeneratorInterface $urlGenerator, PageList $pageList)
     {
         $this->urlGenerator = $urlGenerator;
         $this->pageList = $pageList;
+        $this->routesInfo = $routesInfo;
     }
 
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $this->pageList->add(
-            $this->urlGenerator->generate($name, $parameters, UrlGeneratorInterface::ABSOLUTE_URL)
-        );
+        if (($routeInfo = $this->routesInfo[$name] ?? null) && !$routeInfo->isIgnored()) {
+            $this->pageList->add(
+                $this->urlGenerator->generate($name, $parameters, UrlGeneratorInterface::ABSOLUTE_URL)
+            );
+        }
 
         return $this->urlGenerator->generate($name, $parameters, $referenceType);
     }


### PR DESCRIPTION
Even if a route is explicitly marked as ignored by Stenope in its
routing options, if the route was used to generate an URL inside a
non-ignored route, it'll still be part of the build.

This is problematic, even more when the route is only used to generate
an URL to an external resource.

Let's properly ignore such routes in the UrlGenerator.