### PR TITLE
Fix LastModifiedProcessor

### DIFF
--- a/src/Processor/LastModifiedProcessor.php
+++ b/src/Processor/LastModifiedProcessor.php
@@ -25,7 +25,7 @@ class LastModifiedProcessor implements ProcessorInterface
 
     public function __invoke(array &$data, string $type, Content $content): void
     {
-        if (isset($data[$this->property])) {
+        if (\array_key_exists($this->property, $data)) {
             // Last modified already set.
             return;
         }


### PR DESCRIPTION
to only add the file last modification date if the property is absent from content metadata (so we can keep explicit `null` values)

Actually, I'm not even sure this processor is relevant since it in most cases always matches the last deployment date (last time the repository was cloned).