### PR TITLE
Fix assets processor for schemes like mailto:

### DIFF
--- a/src/Service/AssetUtils.php
+++ b/src/Service/AssetUtils.php
@@ -21,11 +21,9 @@ class AssetUtils
 
     public function getUrl(string $url): string
     {
-        if (preg_match('#^((\w+:)?//)?(.+)$#', $url, $matches)) {
+        if (null === parse_url($url, PHP_URL_SCHEME) && !str_starts_with($url, '//')) {
             // Only process local assets (ignoring urls starting by a scheme or "//").
-            if (!$matches[1]) {
-                return $this->assets->getUrl($matches[3]);
-            }
+            return $this->assets->getUrl($url);
         }
 
         return $url;

--- a/tests/Unit/Service/AssetsUtilsTest.php
+++ b/tests/Unit/Service/AssetsUtilsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Unit\Service;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Stenope\Bundle\Service\AssetUtils;
+use Symfony\Component\Asset\Packages;
+
+class AssetsUtilsTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private AssetUtils $utils;
+
+    protected function setUp(): void
+    {
+        $packages = $this->prophesize(Packages::class);
+        $packages->getUrl(Argument::type('string'))->will(function (array $args): string {
+            [$url] = $args;
+
+            return "https://cnd.example.com/$url";
+        });
+
+        $this->utils = new AssetUtils($packages->reveal());
+    }
+
+    /**
+     * @dataProvider provideGetUrlData
+     */
+    public function testGetUrl(string $url, string $expected): void
+    {
+        self::assertSame($expected, $this->utils->getUrl($url));
+    }
+
+    public function provideGetUrlData(): iterable
+    {
+        yield ['mailto:foo@exemple.com', 'mailto:foo@exemple.com'];
+        yield ['tel:+33606060606', 'tel:+33606060606'];
+        yield ['file:///foo.svg', 'file:///foo.svg'];
+        yield ['http://example.com/bar', 'http://example.com/bar'];
+        yield ['//example.com/bar', '//example.com/bar'];
+        yield ['https://example.com/bar', 'https://example.com/bar'];
+        yield ['foo.png', 'https://cnd.example.com/foo.png'];
+    }
+}


### PR DESCRIPTION
Otherwise it attempts to process links like `tel:XXX`, `mailto:XXX` as assets and might prepend the base url or host.