### PR TITLE
Fix doc anchors: Asset processor should not process anchors

### DIFF
--- a/doc/app/Makefile
+++ b/doc/app/Makefile
@@ -1,25 +1,40 @@
 .SILENT:
-.PHONY: test
+.PHONY: build
+
+###########
+# Install #
+###########
 
 # Install dependencies
 install:
 	composer install
 	npm install
 
+###############
+# Development #
+###############
+
 # Start server
 start:
 	symfony server:start --no-tls
+
+clear:
+	rm -rf build public/build
+
+# Launch watch
+watch:
+	npm run watch
 
 #########
 # Build #
 #########
 
-## Build static site with assets
-build: build-assets build-content
-
 ## Build assets
-build-assets:
+build:
 	npm run build
+
+## Build static site with assets
+build-static: build build-content
 
 ## Build static site
 build-content: export APP_ENV = prod
@@ -32,6 +47,16 @@ serve-static: build-content
 	open http://localhost:8032
 	php -S localhost:8032 -t build
 
-# Launch watch
-watch:
-	npm run watch
+## Simulates GH Pages deploy into a subdir / with base url
+build-subdir: export APP_ENV = prod
+build-subdir: export WEBPACK_PUBLIC_PATH = /stenope/build
+build-subdir: export ROUTER_DEFAULT_URI = http://localhost:8032/stenope
+build-subdir: clear build
+	rm -rf public/resized
+	bin/console cache:clear
+	bin/console stenope:build build/stenope
+
+## Serve the static version of the site from a subdir / with base url
+serve-static-subdir:
+	open http://localhost:8032/stenope
+	php -S localhost:8032 -t build

--- a/src/Service/AssetUtils.php
+++ b/src/Service/AssetUtils.php
@@ -21,7 +21,7 @@ class AssetUtils
 
     public function getUrl(string $url): string
     {
-        if (null === parse_url($url, PHP_URL_SCHEME) && !str_starts_with($url, '//')) {
+        if (null === parse_url($url, PHP_URL_SCHEME) && !str_starts_with($url, '//') && !str_starts_with($url, '#')) {
             // Only process local assets (ignoring urls starting by a scheme or "//").
             return $this->assets->getUrl($url);
         }

--- a/tests/Unit/Service/AssetsUtilsTest.php
+++ b/tests/Unit/Service/AssetsUtilsTest.php
@@ -49,5 +49,6 @@ class AssetsUtilsTest extends TestCase
         yield ['//example.com/bar', '//example.com/bar'];
         yield ['https://example.com/bar', 'https://example.com/bar'];
         yield ['foo.png', 'https://cnd.example.com/foo.png'];
+        yield ['#an-anchor-to-current-page', '#an-anchor-to-current-page'];
     }
 }


### PR DESCRIPTION
Currently, anchors links are broken on the docs (https://stenopephp.github.io/Stenope/loading-content/ => click on any title) and redirects to the base URL.
We should not attempt to resolve such links neither with the assets processor.