### PR TITLE
Fix & enhance the TOC processor

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -181,6 +181,9 @@ return static function (ContainerConfigurator $container): void {
         ->set(TableOfContentProcessor::class)
             ->args([
                 '$generator' => service(CrawlerTableOfContentGenerator::class),
+                '$tableOfContentProperty' => 'tableOfContent',
+                '$contentProperty' => 'content',
+                '$minDepth' => 2,
             ])
             ->tag(tags\content_processor, ['priority' => -100])
     ;

--- a/doc/app/composer.lock
+++ b/doc/app/composer.lock
@@ -720,7 +720,7 @@
             "dist": {
                 "type": "path",
                 "url": "../..",
-                "reference": "434e9daf6e8dc3486865064aa70df277da48a43d"
+                "reference": "c6e9045b83bad156d0a7fe5e16da4b7a775ddb97"
             },
             "require": {
                 "erusev/parsedown": "^1.7.4",

--- a/doc/app/config/packages/dev/monolog.yaml
+++ b/doc/app/config/packages/dev/monolog.yaml
@@ -16,4 +16,4 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
-            channels: ["!event", "!doctrine", "!console"]
+            channels: ["!event", "!doctrine", "!console", "!request"]

--- a/doc/app/config/packages/prod/monolog.yaml
+++ b/doc/app/config/packages/prod/monolog.yaml
@@ -13,4 +13,4 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
-            channels: ["!event", "!doctrine"]
+            channels: ["!event", "!doctrine", "!request"]

--- a/doc/app/config/services.yaml
+++ b/doc/app/config/services.yaml
@@ -29,9 +29,7 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
-    Stenope\Bundle\Processor\TableOfContentProcessor:
-        arguments:
-            $minDepth: 2
-            $maxDepth: 3
+    App\Processor\DefaultTocProcessor:
         tags:
-         - { name: 'stenope.processor', priority: '-100' }
+          - name: 'stenope.processor'
+            priority: '-90' # before the TableOfContentProcessor

--- a/doc/app/src/Model/Page.php
+++ b/doc/app/src/Model/Page.php
@@ -2,12 +2,15 @@
 
 namespace App\Model;
 
+use Stenope\Bundle\TableOfContent\Headline;
+
 class Page
 {
     public string $title;
     public string $slug;
     public string $content;
-    public array $tableOfContent;
+    /** @var Headline[] */
+    public array $tableOfContent = [];
     public \DateTimeInterface $created;
     public \DateTimeInterface $lastModified;
 }

--- a/doc/app/src/Processor/DefaultTocProcessor.php
+++ b/doc/app/src/Processor/DefaultTocProcessor.php
@@ -10,7 +10,7 @@ class DefaultTocProcessor implements ProcessorInterface
 {
     private string $tableOfContentProperty;
 
-    public function __construct($tableOfContentProperty = 'tableOfContent')
+    public function __construct(string $tableOfContentProperty = 'tableOfContent')
     {
         $this->tableOfContentProperty = $tableOfContentProperty;
     }

--- a/doc/app/src/Processor/DefaultTocProcessor.php
+++ b/doc/app/src/Processor/DefaultTocProcessor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Processor;
+
+use App\Model\Page;
+use Stenope\Bundle\Behaviour\ProcessorInterface;
+use Stenope\Bundle\Content;
+
+class DefaultTocProcessor implements ProcessorInterface
+{
+    private string $tableOfContentProperty;
+
+    public function __construct($tableOfContentProperty = 'tableOfContent')
+    {
+        $this->tableOfContentProperty = $tableOfContentProperty;
+    }
+
+    public function __invoke(array &$data, string $type, Content $content): void
+    {
+        if (!is_a($type, Page::class, true)) {
+            return;
+        }
+
+        if (!isset($data[$this->tableOfContentProperty])) {
+            // By default, always generate a TOC for pages, with max depth of 3:
+            $data[$this->tableOfContentProperty] = 3;
+        }
+    }
+}

--- a/doc/app/templates/doc/index.html.twig
+++ b/doc/app/templates/doc/index.html.twig
@@ -1,3 +1,8 @@
 {% extends 'base.html.twig' %}
 
 {% block content page.content|raw %}
+
+{% block sidebar %}
+    {{ parent() }}
+    {% include 'component/table_of_content.html.twig' with { tableOfContent: page.tableOfContent } %}
+{% endblock %}

--- a/tests/Integration/BuildTest.php
+++ b/tests/Integration/BuildTest.php
@@ -88,9 +88,11 @@ class BuildTest extends KernelTestCase
             'http://localhost/foo.html',
             'http://localhost/authors/john.doe',
             'http://localhost/authors/ogi',
+            'http://localhost/authors/tom32i',
             'http://localhost/recipes/',
             'http://localhost/recipes/cheesecake',
             'http://localhost/recipes/ogito',
+            'http://localhost/recipes/tomiritsu',
         ], $crawler->filter('url > loc')->extract(['_text']));
     }
 
@@ -119,6 +121,7 @@ class BuildTest extends KernelTestCase
         self::assertSame([
             'http://localhost/recipes/cheesecake',
             'http://localhost/recipes/ogito',
+            'http://localhost/recipes/tomiritsu',
         ], $links, 'all recipes links generated in right order');
     }
 

--- a/tests/Integration/TableOfContentTest.php
+++ b/tests/Integration/TableOfContentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TableOfContentTest extends WebTestCase
+{
+    private static array $kernelOptions = [
+        'environment' => 'prod',
+        'debug' => true,
+    ];
+
+    public function testItResolvesTableOfContent(): void
+    {
+        $client = self::createClient(self::$kernelOptions);
+        $client->request('GET', '/recipes/ogito');
+
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorExists('.table-of-content');
+        self::assertSelectorTextContains('.table-of-content > ol > li:nth-child(1)', 'First step');
+        self::assertSelectorTextContains('.table-of-content > ol > li:nth-child(1) li', 'Sub-step');
+        self::assertSelectorTextContains('.table-of-content > ol > li:nth-child(2)', 'Second step');
+    }
+
+    public function testItResolvesTableOfContentWithLimit(): void
+    {
+        $client = self::createClient(self::$kernelOptions);
+        $client->request('GET', '/recipes/cheesecake');
+
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorExists('.table-of-content');
+        self::assertSelectorTextContains('.table-of-content > ol > li:nth-child(1)', 'First step');
+        self::assertSelectorNotExists('.table-of-content > ol > li:nth-child(1) li');
+        self::assertSelectorTextContains('.table-of-content > ol > li:nth-child(2)', 'Second step');
+    }
+
+    public function testDisabledTableOfContent(): void
+    {
+        $client = self::createClient(self::$kernelOptions);
+        $client->request('GET', '/recipes/tomiritsu');
+
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorNotExists('.table-of-content');
+    }
+}

--- a/tests/Unit/TableOfContent/CrawlerTableOfContentGeneratorTest.php
+++ b/tests/Unit/TableOfContent/CrawlerTableOfContentGeneratorTest.php
@@ -102,5 +102,16 @@ class CrawlerTableOfContentGeneratorTest extends TestCase
                 new Headline(2, 'AC', 'Donec laoreet'),
             ],
         ];
+
+        yield 'single level' => [
+            $content,
+            2,
+            2,
+            [
+                new Headline(2, 'AA', 'Suspendisse'),
+                new Headline(2, 'AB', 'Nam sed neque'),
+                new Headline(2, 'AC', 'Donec laoreet'),
+            ],
+        ];
     }
 }

--- a/tests/fixtures/app/content/authors/tom32i.md
+++ b/tests/fixtures/app/content/authors/tom32i.md
@@ -1,0 +1,8 @@
+---
+lastname: Jarrand
+firstname: Thomas
+nickname: tom32i
+tags: ["symfony", "cooking"]
+---
+
+I'm coding on both ends of the HTTP request. ✨

--- a/tests/fixtures/app/content/recipes/ogito.md
+++ b/tests/fixtures/app/content/recipes/ogito.md
@@ -5,6 +5,7 @@ authors: ["ogi"]
 tags: ["cocktails"]
 categories: ["drink"]
 date: 2019/10/22
+tableOfContent: true
 ---
 
 Learn how to make an Ogito with the following recipe.
@@ -12,3 +13,15 @@ Learn how to make an Ogito with the following recipe.
 Also see the [famous cheesecake recipe](cheesecake.md) for more yum!
 
 Cheers [Ogi](../authors/ogi.md) for this recipe.
+
+## First step
+
+Studere recte ducunt ad grandis ausus.
+
+### Sub-step
+
+Lamias volare, tanquam emeritis rumor.
+
+## Second step
+
+Amors peregrinatione, tanquam peritus zelus.

--- a/tests/fixtures/app/content/recipes/tomiritsu.md
+++ b/tests/fixtures/app/content/recipes/tomiritsu.md
@@ -1,14 +1,14 @@
 ---
-description: Craft your own cheesecake!
-title: The cheesecake
-authors: ["ogi"]
+description: The best tiramitsu by Tom
+title: The Tomiritsu
+authors: ["tom32i"]
 tags: ["cooking", "dessert"]
 categories: ["awesome"]
-date: 2020/06/18 
-tableOfContent: 2
+date: 2019/10/22
+tableOfContent: false
 ---
 
-Craft your own cheese cake with the following recipe!
+When grilling aged ghees, be sure they are room temperature.
 
 ## First step
 

--- a/tests/fixtures/app/content/recipes/tomiritsu.md
+++ b/tests/fixtures/app/content/recipes/tomiritsu.md
@@ -4,7 +4,7 @@ title: The Tomiritsu
 authors: ["tom32i"]
 tags: ["cooking", "dessert"]
 categories: ["awesome"]
-date: 2019/10/22
+date: 2019/10/21
 tableOfContent: false
 ---
 

--- a/tests/fixtures/app/src/Model/Recipe.php
+++ b/tests/fixtures/app/src/Model/Recipe.php
@@ -8,12 +8,16 @@
 
 namespace App\Model;
 
+use Stenope\Bundle\TableOfContent\Headline;
+
 class Recipe
 {
     public string $title;
     public ?string $description = null;
     public string $slug;
     public string $content;
+    /** @var Headline[] */
+    public array $tableOfContent = [];
     public array $authors;
     public array $tags;
     public \DateTimeInterface $date;

--- a/tests/fixtures/app/templates/recipe/show.html.twig
+++ b/tests/fixtures/app/templates/recipe/show.html.twig
@@ -1,6 +1,27 @@
 {% extends 'base.html.twig' %}
 
 {% block content %}
+
+    {% if recipe.tableOfContent is not empty %}
+        <div class="table-of-content">
+            <p class="title">Table of content</p>
+            <ol class="list">
+                {% for headline in recipe.tableOfContent %}
+                    <li>
+                        <a href="#{{ headline.id }}">{{ headline.content }}</a>
+                        {% if headline.children is not empty %}
+                            <ol class="sub-list">
+                                {% for child in headline.children %}
+                                    <li><a href="#{{ child.id }}">{{ child.content }}</a></li>
+                                {% endfor %}
+                            </ol>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ol>
+        </div>
+    {% endif %}
+
     <h1>{{ recipe.title }}</h1>
 
     {{ recipe.content|raw }}


### PR DESCRIPTION
Fixes the TOC processor in case there is no content property in the expected model.

Additionally, I suggest multiple changes to enhance the default integration:
- change the wired min depth to h2, since most of the time, h1 are unique, on top of the page and thus useless in a TOC
- make the TOC generation opt-in, so it won't be generated for every contents by default, but can be enabled using `tableOfContent: true` or an int value (see below). It can also be easily enabled automatically using another processor for some types, as done for the documentation here. `false` can be used in such cases to explicitly disable it.
- allow to configure the max depth per content, using an int value for the `tableOfContent` metadata.

These changes aim to provide better defaults so we can keep this processor enabled out-of-the box, but we may go further with it in https://github.com/StenopePHP/Stenope/issues/90.
It also matches our expectations for the [elao_ blog](https://github.com/Elao/elao_/pull/342).