### PR TITLE
Add a debug CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Stenope is not a ready-to-use bloging system: but you could quickly _write your 
 ### Features
 
 - [CLI usage](doc/cli.md)
+- [Debug contents](doc/cli.md#debug)
 - [Loading and parsing content](doc/loading-content.md)
 - [Supported formats](doc/supported-formats.md)
 - [Supported sources](doc/supported-sources.md)

--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,7 @@ use Stenope\Bundle\Builder;
 use Stenope\Bundle\Builder\PageList;
 use Stenope\Bundle\Builder\Sitemap;
 use Stenope\Bundle\Command\BuildCommand;
+use Stenope\Bundle\Command\DebugCommand;
 use Stenope\Bundle\ContentManager;
 use Stenope\Bundle\Decoder\HtmlDecoder;
 use Stenope\Bundle\Decoder\MarkdownDecoder;
@@ -67,6 +68,13 @@ return static function (ContainerConfigurator $container): void {
         // Content providers factories
         ->set(ContentProviderFactory::class)->args(['$factories' => tagged_iterator(tags\content_provider_factory)])
         ->set(LocalFilesystemProviderFactory::class)->tag(tags\content_provider_factory)
+
+        // Debug
+        ->set(DebugCommand::class)->args([
+            '$manager' => service(ContentManager::class),
+            '$stopwatch' => service('stenope.build.stopwatch'),
+        ])
+        ->tag('console.command', ['command' => DebugCommand::getDefaultName()])
 
         // Build
         ->set(BuildCommand::class)->args([

--- a/doc/app/README.md
+++ b/doc/app/README.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-### Depenencies
+### Dependencies
 
     make install
 

--- a/doc/app/composer.lock
+++ b/doc/app/composer.lock
@@ -720,7 +720,7 @@
             "dist": {
                 "type": "path",
                 "url": "../..",
-                "reference": "c6e9045b83bad156d0a7fe5e16da4b7a775ddb97"
+                "reference": "3abb2627d671319e23f8ed08a744e09585a2fca2"
             },
             "require": {
                 "erusev/parsedown": "^1.7.4",

--- a/doc/app/config/packages/stenope.yaml
+++ b/doc/app/config/packages/stenope.yaml
@@ -12,6 +12,7 @@ stenope:
                 - vendor
             patterns:
                 - '*.md'
+            depth: <=1
 
         App\Model\Page:
             type: files

--- a/doc/app/src/Model/Page.php
+++ b/doc/app/src/Model/Page.php
@@ -2,15 +2,14 @@
 
 namespace App\Model;
 
-use Stenope\Bundle\TableOfContent\Headline;
+use Stenope\Bundle\TableOfContent\TableOfContent;
 
 class Page
 {
     public string $title;
     public string $slug;
     public string $content;
-    /** @var Headline[] */
-    public array $tableOfContent = [];
+    public ?TableOfContent $tableOfContent = null;
     public \DateTimeInterface $created;
     public \DateTimeInterface $lastModified;
 }

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,12 +1,14 @@
 # CLI
 
+## Build
+
 The build command:
 
 ```shell
 bin/console stenope:build [options] [--] [<buildDir>]
 ```
 
-## Building into a specific directory
+### Building into a specific directory
 
 Use the `buildDir` argument:
 
@@ -14,7 +16,7 @@ Use the `buildDir` argument:
 bin/console stenope:build ./static
 ```
 
-## Options
+### Options
 
 | Option | Description |
 | -- | -- | -- |
@@ -24,3 +26,23 @@ bin/console stenope:build ./static
 | `--no-sitemap` | Don't build the sitemap | |
 | `--no-expose` | Don't expose the public directory | |
 | `--ignore-content-not-found` | Ignore content not found errors | |
+
+## Debug
+
+There is a command to list, filter, sort out and display content managed by Stenope:
+
+```shell
+bin/console debug:stenope:content [options] [--] <class> [<id>]
+```
+
+E.g:
+
+```shell
+bin/console debug:stenope:content "App\Model\Article" --filter="not:outdated" --filter="slug contains:symfony" --order="desc:publishedAt"
+```
+
+```shell
+bin/console debug:stenope:content "App\Model\Author" ogi
+```
+
+Use `--help` for more details and usage samples.

--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -208,6 +208,10 @@ $tagedMobileArticles = $this->manager->getContents(
 );
 ```
 
+## Debug
+
+See [CLI - Debug](./cli.md#debug)
+
 ## Advanced usage and extension
 
 ### Register a custom denormalizer

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Stenope\Bundle\Builder\PageList;
 use Stenope\Bundle\Builder\Sitemap;
-use Stenope\Bundle\Exception\RuntimeException;
+use Stenope\Bundle\Exception\ContentNotFoundException;
 use Stenope\Bundle\HttpFoundation\ContentRequest;
 use Stenope\Bundle\Routing\RouteInfoCollection;
 use Symfony\Component\Console\Helper\Helper;
@@ -27,7 +27,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Twig\Environment;
@@ -376,7 +375,7 @@ class Builder
         try {
             $response = $this->httpKernel->handle($request, HttpKernelInterface::MASTER_REQUEST, false);
         } catch (\Throwable $exception) {
-            if ($ignoreContentNotFoundErrors && $exception instanceof RuntimeException) {
+            if ($ignoreContentNotFoundErrors && $exception instanceof ContentNotFoundException) {
                 $this->logger->warning('Could not build url "{url}": {exception}', [
                     'exception' => $exception->getMessage(),
                     'url' => $url,

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Stenope\Bundle\Builder\PageList;
 use Stenope\Bundle\Builder\Sitemap;
-use Stenope\Bundle\Exception\ContentNotFoundException;
+use Stenope\Bundle\Exception\RuntimeException;
 use Stenope\Bundle\HttpFoundation\ContentRequest;
 use Stenope\Bundle\Routing\RouteInfoCollection;
 use Symfony\Component\Console\Helper\Helper;
@@ -376,7 +376,7 @@ class Builder
         try {
             $response = $this->httpKernel->handle($request, HttpKernelInterface::MASTER_REQUEST, false);
         } catch (\Throwable $exception) {
-            if ($ignoreContentNotFoundErrors && $exception instanceof ContentNotFoundException) {
+            if ($ignoreContentNotFoundErrors && $exception instanceof RuntimeException) {
                 $this->logger->warning('Could not build url "{url}": {exception}', [
                     'exception' => $exception->getMessage(),
                     'url' => $url,

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -10,7 +10,6 @@ namespace Stenope\Bundle\Command;
 
 use Stenope\Bundle\Builder;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,13 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Stopwatch\Stopwatch;
-use Symfony\Component\Stopwatch\StopwatchEvent;
 
-/**
- * Build Command
- */
 class BuildCommand extends Command
 {
+    use StopwatchHelperTrait;
+
     protected static $defaultName = 'stenope:build';
 
     private Builder $builder;
@@ -46,7 +43,6 @@ class BuildCommand extends Command
     {
         $this
             ->setDescription('Build static website')
-            ->setHelp('...')
             ->addArgument(
                 'buildDir',
                 InputArgument::OPTIONAL,
@@ -158,50 +154,6 @@ class BuildCommand extends Command
         $io->success("Built $count pages.\n" . self::formatEvent($this->stopwatch->getEvent('build')));
 
         return Command::SUCCESS;
-    }
-
-    public static function formatTimePrecision($secs)
-    {
-        static $timeFormats = [
-            [0, 'sec', 1, 2],
-            [2, 'secs', 1, 2],
-            [60, '1 min'],
-            [120, 'mins', 60],
-            [3600, '1 hr'],
-            [7200, 'hrs', 3600],
-            [86400, '1 day'],
-            [172800, 'days', 86400],
-        ];
-
-        foreach ($timeFormats as $index => $format) {
-            if ($secs >= $format[0]) {
-                if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
-                    || $index == \count($timeFormats) - 1
-                ) {
-                    switch (\count($format)) {
-                        case 2:
-                            return $format[1];
-
-                        case 4:
-                            return round($secs / $format[2], $format[3]) . ' ' . $format[1];
-
-                        default:
-                            return floor($secs / $format[2]) . ' ' . $format[1];
-                    }
-                }
-            }
-        }
-    }
-
-    public static function formatEvent(StopwatchEvent $event): string
-    {
-        return sprintf(
-            'Start time: %s — End time: %s — Duration: %s — Memory used: %s',
-            date('H:i:s', ($event->getOrigin() + $event->getStartTime()) / 1000),
-            date('H:i:s', ($event->getOrigin() + $event->getEndTime()) / 1000),
-            static::formatTimePrecision($event->getDuration() / 1000),
-            Helper::formatMemory($event->getMemory())
-        );
     }
 }
 

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -74,6 +74,10 @@ class DebugCommand extends Command
 
                 <info>php %command.full_name% "App\Model\Author" --order="desc:integrationDate"</info>
 
+                same as:
+
+                <info>php %command.full_name% "App\Model\Author" --order="-integrationDate"</info>
+
             You can order by multiple fields:
 
                 <info>php %command.full_name% "App\Model\Author" --order="desc:active" --order="integrationDate"</info>
@@ -90,7 +94,7 @@ class DebugCommand extends Command
 
                 same as:
 
-                <info>php %command.full_name% "App\Model\Author" --filter="-active"</info>
+                <info>php %command.full_name% "App\Model\Author" --filter="!active"</info>
 
             Contains:
 
@@ -143,6 +147,10 @@ class DebugCommand extends Command
                 $orders[substr($field, 5)] = false;
                 continue;
             }
+            if (\str_starts_with($field, '-')) {
+                $orders[substr($field, 1)] = false;
+                continue;
+            }
 
             $orders[$field] = true;
         }
@@ -157,20 +165,14 @@ class DebugCommand extends Command
             $matches = [];
             if (preg_match('#^(\w+) contains:(.*)$#', $field, $matches)) {
                 $searched = $matches[2];
-                $filters[$matches[1]] = static function ($value) use ($searched) {
-                    if (!\is_string($value)) {
-                        return false;
-                    }
-
-                    return str_contains($value, $searched);
-                };
+                $filters[$matches[1]] = static fn ($value) => \is_string($value) ? str_contains($value, $searched) : false;
                 continue;
             }
             if (\str_starts_with($field, 'not:')) {
                 $filters[substr($field, 4)] = false;
                 continue;
             }
-            if (\str_starts_with($field, '-')) {
+            if (\str_starts_with($field, '!')) {
                 $filters[substr($field, 1)] = false;
                 continue;
             }

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Command;
+
+use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\TableOfContent\Headline;
+use Stenope\Bundle\TableOfContent\TableOfContent;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Dumper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+class DebugCommand extends Command
+{
+    use StopwatchHelperTrait;
+
+    protected static $defaultName = 'debug:stenope:content';
+
+    private ContentManager $manager;
+    private Stopwatch $stopwatch;
+
+    public function __construct(ContentManager $manager, Stopwatch $stopwatch)
+    {
+        $this->manager = $manager;
+        $this->stopwatch = $stopwatch;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Debug Stenope managed contents')
+            ->addArgument('class', InputArgument::REQUIRED, 'Content FQCN')
+            ->addArgument('id', InputArgument::OPTIONAL, 'Content identifier')
+            ->addOption('order', 'o', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Order by field(s)')
+            ->addOption('filter', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Filter by field(s)')
+            ->setHelp(<<<HELP
+            The <info>%command.name%</info> allows to list and display content managed by Stenope:
+
+                <info>php %command.full_name% "App\Model\Author"</info>
+
+            will list all authors.
+
+                <info>php %command.full_name% "App\Model\Author ogi"</info>
+
+            will fetch and display the processed Author with id "ogi".
+
+            Change <info>verbosity</info> in order to get more details <comment>(-v, -vv, -vvv)</comment>.
+
+            --- Sort
+
+            The command allows to order the list:
+
+                <info>php %command.full_name% "App\Model\Author" --order="slug"</info>
+                <info>php %command.full_name% "App\Model\Author" --order="integrationDate"</info>
+
+            In <info>desc</info> order:
+
+                <info>php %command.full_name% "App\Model\Author" --order="desc:integrationDate"</info>
+
+            You can order by multiple fields:
+
+                <info>php %command.full_name% "App\Model\Author" --order="desc:active" --order="integrationDate"</info>
+
+            --- Filter
+
+            The command allows to filter out the list in various ways:
+
+                <info>php %command.full_name% "App\Model\Author" --filter=active</info>
+
+            Negation:
+
+                <info>php %command.full_name% "App\Model\Author" --filter="not:active"</info>
+
+                same as:
+
+                <info>php %command.full_name% "App\Model\Author" --filter="-active"</info>
+
+            Contains:
+
+                <info>php %command.full_name% "App\Model\Article" --filter="slug contains:symfony"</info>
+
+            You can also use multiple filters at once:
+
+                <info>php %command.full_name% "App\Model\Article" --filter="not:outdated" --filter="slug contains:symfony"</info>
+            HELP
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Debug Stenope Contents');
+
+        $class = $input->getArgument('class');
+        $id = $input->getArgument('id');
+
+        if (!$this->stopwatch->isStarted('fetch')) {
+            $this->stopwatch->start('fetch', 'stenope');
+        }
+
+        if (null === $id) {
+            $this->list($io, $class, $this->geOrders($input), $this->getFilters($input));
+        } else {
+            $this->describe($io, $class, $id);
+        }
+
+        if ($this->stopwatch->isStarted('fetch')) {
+            $this->stopwatch->stop('fetch');
+        }
+
+        $io->comment("Fetched info:\n" . self::formatEvent($this->stopwatch->getEvent('fetch')));
+
+        return Command::SUCCESS;
+    }
+
+    private function geOrders(InputInterface $input): array
+    {
+        $orders = [];
+        foreach ($input->getOption('order') ?? [] as $field) {
+            if (\str_starts_with($field, 'desc:')) {
+                $orders[substr($field, 5)] = false;
+                continue;
+            }
+
+            $orders[$field] = true;
+        }
+
+        return $orders;
+    }
+
+    private function getFilters(InputInterface $input): array
+    {
+        $filters = [];
+        foreach ($input->getOption('filter') ?? [] as $field) {
+            $matches = [];
+            if (preg_match('#^(\w+) contains:(.*)$#', $field, $matches)) {
+                $searched = $matches[2];
+                $filters[$matches[1]] = static function ($value) use ($searched) {
+                    if (!\is_string($value)) {
+                        return false;
+                    }
+
+                    return str_contains($value, $searched);
+                };
+                continue;
+            }
+            if (\str_starts_with($field, 'not:')) {
+                $filters[substr($field, 4)] = false;
+                continue;
+            }
+            if (\str_starts_with($field, '-')) {
+                $filters[substr($field, 1)] = false;
+                continue;
+            }
+
+            $filters[$field] = true;
+        }
+
+        return $filters;
+    }
+
+    private function list(SymfonyStyle $io, string $class, array $sort, array $filters): void
+    {
+        $io->section("\"$class\" items");
+
+        $list = $this->manager->getContents($class, $sort, $filters);
+
+        $io->listing(array_keys($list));
+
+        $io->note(sprintf('Found %d items', \count($list)));
+    }
+
+    private function describe(SymfonyStyle $io, string $class, string $id): void
+    {
+        $io->section("\"$class\" item with id \"$id\"");
+
+        $item = $this->manager->getContent($class, $id);
+
+        $cloner = new VarCloner();
+
+        if (!$io->isVeryVerbose()) {
+            // Except on very verbose mode, display a simplified TOC representation:
+            $cloner->addCasters([
+                TableOfContent::class => \Closure::fromCallable([self::class, 'castTableOfContent']),
+            ]);
+        }
+
+        // Show full strings on very verbose mode:
+        $cloner->setMaxString($io->isVeryVerbose() ? -1 : 250);
+        // Show full data tree on verbose mode:
+        $cloner->setMaxItems($io->isVerbose() ? -1 : 15);
+        $dump = new Dumper($io, null, $cloner);
+
+        $io->writeln($dump($item));
+    }
+
+    private static function castTableOfContent(TableOfContent $toc, array $a, Stub $s): array
+    {
+        $appendHeadline = static function (&$headlines, Headline $headline) use (&$appendHeadline): void {
+            $childHeadlines = [];
+            foreach ($headline->getChildren() as $child) {
+                $appendHeadline($childHeadlines, $child);
+            }
+
+            $headlines["H{$headline->getLevel()} - {$headline->getContent()}"] = $childHeadlines;
+        };
+
+        $headlines = [];
+        /** @var Headline $headline */
+        foreach ($toc as $headline) {
+            $appendHeadline($headlines, $headline);
+        }
+
+        $s->type = Stub::TYPE_ARRAY;
+        $s->class = Stub::ARRAY_ASSOC;
+        $s->value = 'headlines';
+
+        return $headlines;
+    }
+}

--- a/src/Command/StopwatchHelperTrait.php
+++ b/src/Command/StopwatchHelperTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Command;
+
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Stopwatch\StopwatchEvent;
+
+trait StopwatchHelperTrait
+{
+    private static function formatEvent(StopwatchEvent $event): string
+    {
+        return sprintf(
+            'Start time: %s — End time: %s — Duration: %s — Memory used: %s',
+            date('H:i:s', ($event->getOrigin() + $event->getStartTime()) / 1000),
+            date('H:i:s', ($event->getOrigin() + $event->getEndTime()) / 1000),
+            static::formatTimePrecision($event->getDuration() / 1000),
+            Helper::formatMemory($event->getMemory())
+        );
+    }
+
+    private static function formatTimePrecision($secs): string
+    {
+        static $timeFormats = [
+            [0, 'sec', 1, 2],
+            [2, 'secs', 1, 2],
+            [60, '1 min'],
+            [120, 'mins', 60],
+            [3600, '1 hr'],
+            [7200, 'hrs', 3600],
+            [86400, '1 day'],
+            [172800, 'days', 86400],
+        ];
+
+        foreach ($timeFormats as $index => $format) {
+            if ($secs >= $format[0]) {
+                if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
+                    || $index === \count($timeFormats) - 1
+                ) {
+                    switch (\count($format)) {
+                        case 2:
+                            return $format[1];
+
+                        case 4:
+                            return round($secs / $format[2], $format[3]) . ' ' . $format[1];
+
+                        default:
+                            return floor($secs / $format[2]) . ' ' . $format[1];
+                    }
+                }
+            }
+        }
+
+        return '0 sec';
+    }
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Exception;
+
+/**
+ * Generic Stenope exception for runtime issues.
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Processor/ResolveContentLinksProcessor.php
+++ b/src/Processor/ResolveContentLinksProcessor.php
@@ -78,10 +78,15 @@ class ResolveContentLinksProcessor implements ProcessorInterface, ContentManager
         }
 
         // Internal content link
-        $context = new RelativeLinkContext($currentContent->getMetadata(), $href);
+        $path = parse_url($href, PHP_URL_PATH);
+        // Extract fragment (hash / anchor, if any)
+        $fragment = parse_url($href, PHP_URL_FRAGMENT);
+
+        $context = new RelativeLinkContext($currentContent->getMetadata(), $path);
         if ($content = $this->contentManager->reverseContent($context)) {
             $url = $this->resolver->resolveUrl($content);
-            $link->setAttribute('href', $url);
+            // redirect to proper content, with specified anchor:
+            $link->setAttribute('href', $fragment ? "$url#$fragment" : $url);
         }
     }
 }

--- a/src/TableOfContent/CrawlerTableOfContentGenerator.php
+++ b/src/TableOfContent/CrawlerTableOfContentGenerator.php
@@ -18,7 +18,7 @@ class CrawlerTableOfContentGenerator
     /**
      * @return Headline[]
      */
-    public function getTableOfContent(string $content, ?int $fromDepth = null, ?int $toDepth = null): array
+    public function getTableOfContent(string $content, ?int $fromDepth = null, ?int $toDepth = null): TableOfContent
     {
         $crawler = new Crawler($content);
 
@@ -30,7 +30,7 @@ class CrawlerTableOfContentGenerator
         }
 
         $filters = $this->getFilters($fromDepth ?? static::MIN_DEPTH, $toDepth ?? static::MAX_DEPTH);
-        $tableOfContent = [];
+        $headlines = [];
         $previous = null;
 
         /* @var \DOMElement $element */
@@ -42,14 +42,14 @@ class CrawlerTableOfContentGenerator
             $previous = $current;
 
             if ($parent === null) {
-                $tableOfContent[] = $current;
+                $headlines[] = $current;
                 continue;
             }
 
             $parent->addChild($current);
         }
 
-        return $tableOfContent;
+        return new TableOfContent($headlines);
     }
 
     private function getFilters(int $fromDepth, int $toDepth): string

--- a/src/TableOfContent/TableOfContent.php
+++ b/src/TableOfContent/TableOfContent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\TableOfContent;
+
+/**
+ * @implements \IteratorAggregate<Headline>
+ */
+class TableOfContent extends \ArrayObject
+{
+    /**
+     * @param Headline[] $headlines
+     */
+    public function __construct(array $headlines = [])
+    {
+        parent::__construct($headlines, 0, \ArrayIterator::class);
+    }
+}

--- a/tests/Integration/Command/DebugCommandTest.php
+++ b/tests/Integration/Command/DebugCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Integration\Command;
+
+use App\Model\Author;
+use Stenope\Bundle\Command\DebugCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DebugCommandTest extends KernelTestCase
+{
+    /**
+     * @dataProvider provide testList data
+     */
+    public function testList(string $class, string $expected, array $filters = [], array $orders = []): void
+    {
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find(DebugCommand::getDefaultName());
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'class' => $class,
+            '--filter' => $filters,
+            '--order' => $orders,
+        ]);
+
+        self::assertStringMatchesFormat(<<<TXT
+
+            Debug Stenope Contents
+            ======================
+
+            "$class" items
+            --------------%A
+
+            $expected
+
+             ! [NOTE] Found %d items %w
+
+            %A
+            TXT
+            , $tester->getDisplay(true));
+    }
+
+    public function provide testList data(): iterable
+    {
+        yield 'list' => [Author::class,
+            <<<TXT
+             * tom32i
+             * john.doe
+             * ogi
+            TXT
+        ];
+
+        yield 'order' => [Author::class,
+            <<<TXT
+             * john.doe
+             * ogi
+             * tom32i
+            TXT
+        , [], ['slug'], ];
+
+        yield 'order desc:' => [Author::class,
+            <<<TXT
+             * tom32i
+             * ogi
+             * john.doe
+            TXT
+        , [], ['desc:slug'], ];
+
+        yield 'order desc (- notation)' => [Author::class,
+            <<<TXT
+             * tom32i
+             * ogi
+             * john.doe
+            TXT
+        , [], ['-slug'], ];
+
+        yield 'filter' => [Author::class,
+            <<<TXT
+             * tom32i
+             * ogi
+            TXT
+        , ['core'], ];
+
+        yield 'filter not:' => [Author::class,
+            <<<TXT
+             * john.doe
+            TXT
+        , ['not:core'], ];
+
+        yield 'filter not: (! notation)' => [Author::class,
+            <<<TXT
+             * john.doe
+            TXT
+        , ['!core'], ];
+
+        yield 'contains:' => [Author::class,
+            <<<TXT
+             * tom32i
+             * ogi
+            TXT
+            , ['slug contains:i'], ];
+
+        yield 'filter and order' => [Author::class,
+            <<<TXT
+             * ogi
+             * tom32i
+            TXT
+        , ['core'], ['slug'], ];
+
+        yield 'multiple filters' => [Author::class,
+            <<<TXT
+             * ogi
+            TXT
+        , ['core', 'slug contains:gi'], ];
+    }
+
+    public function testShow(): void
+    {
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find(DebugCommand::getDefaultName());
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'class' => Author::class,
+            'id' => 'ogi',
+        ]);
+
+        self::assertStringMatchesFormat(
+            <<<TXT
+
+            Debug Stenope Contents
+            ======================
+
+            "App\Model\Author" item with id "ogi"
+            -------------------------------------
+
+            App\Model\Author {
+              +slug: "ogi"
+              +firstname: "Maxime"
+              +lastname: "Steinhausser"
+              +nickname: "ogi"
+              %A
+            }
+
+            %A
+            TXT,
+            $tester->getDisplay(true)
+        );
+    }
+}

--- a/tests/Integration/ResolvedLinkedContentsTest.php
+++ b/tests/Integration/ResolvedLinkedContentsTest.php
@@ -25,7 +25,8 @@ class ResolvedLinkedContentsTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertStringContainsString(
             <<<HTML
-            Cheers <a href="/authors/ogi">Ogi</a> for this recipe
+            Cheers <a href="/authors/ogi">Ogi</a> for this recipe.
+            Check his <a href="/authors/ogi#recipes">other recipes</a>.
             HTML,
             $client->getResponse()->getContent(),
             'Response contains proper link to author'

--- a/tests/Unit/ContentManagerTest.php
+++ b/tests/Unit/ContentManagerTest.php
@@ -84,37 +84,48 @@ class ContentManagerTest extends TestCase
             })
             ->shouldBeCalledTimes(3)
         ;
-        self::assertSame([
-            'Foo 1',
-            'Foo 2',
-            'Foo 3',
-        ], array_column($manager->getContents('App\Foo'), 'content'), 'no sort');
+
+        $getResults = static fn (array $results): array => array_combine(array_keys($results), array_column($results, 'content'));
 
         self::assertSame([
-            'Foo 2',
-            'Foo 1',
-            'Foo 3',
-        ], array_column($manager->getContents('App\Foo', 'order'), 'content'), 'asc order, directly as string');
+            'foo1' => 'Foo 1',
+            'foo2' => 'Foo 2',
+            'foo3' => 'Foo 3',
+        ], $getResults($manager->getContents('App\Foo')), 'no sort');
 
         self::assertSame([
-            'Foo 3',
-            'Foo 1',
-            'Foo 2',
-        ], array_column($manager->getContents('App\Foo', ['order' => false]), 'content'), 'desc order');
+            'foo2' => 'Foo 2',
+            'foo1' => 'Foo 1',
+            'foo3' => 'Foo 3',
+        ], $getResults($manager->getContents('App\Foo', 'order')), 'asc order, directly as string');
 
         self::assertSame([
-            'Foo 2',
-            'Foo 1',
-            'Foo 3',
-        ], array_column($manager->getContents('App\Foo', fn ($a, $b) => $a->order <=> $b->order), 'content'), 'ordered by function');
+            'foo3' => 'Foo 3',
+            'foo1' => 'Foo 1',
+            'foo2' => 'Foo 2',
+        ], $getResults($manager->getContents('App\Foo', ['order' => false])), 'desc order');
 
         self::assertSame([
-            'Foo 1',
-        ], array_column($manager->getContents('App\Foo', null, ['content' => 'Foo 1']), 'content'), 'filtered by key');
+            'foo2' => 'Foo 2',
+            'foo1' => 'Foo 1',
+            'foo3' => 'Foo 3',
+        ], $getResults($manager->getContents('App\Foo', fn ($a, $b) => $a->order <=> $b->order)), 'ordered by function');
 
         self::assertSame([
-            'Foo 2',
-        ], array_column($manager->getContents('App\Foo', null, fn ($foo) => $foo->content === 'Foo 2'), 'content'), 'filtered by function');
+            'foo1' => 'Foo 1',
+        ], $getResults($manager->getContents('App\Foo', null, ['content' => 'Foo 1'])), 'filtered by key');
+
+        self::assertSame([
+            'foo1' => 'Foo 1',
+        ], $getResults($manager->getContents(
+            'App\Foo',
+            null,
+            ['content' => static fn ($content) => $content === 'Foo 1'],
+        )), 'filtered with a property function');
+
+        self::assertSame([
+            'foo2' => 'Foo 2',
+        ], $getResults($manager->getContents('App\Foo', null, fn ($foo) => $foo->content === 'Foo 2')), 'filtered by function');
     }
 
     public function testReverseContent(): void

--- a/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
+++ b/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
@@ -30,6 +30,7 @@ class ResolveContentLinksProcessorTest extends TestCase
             <a href="#anchor">Don't change this</a>
 
             <a href="../other-contents/another-content.md">Another content</a>
+            <a href="../other-contents/another-content.md#some-anchor">Another content with anchor</a>
             HTML,
         ];
 
@@ -48,13 +49,13 @@ class ResolveContentLinksProcessorTest extends TestCase
         $manager->reverseContent(new RelativeLinkContext(
             $currentContent->getMetadata(),
             '../other-contents/another-content.md',
-        ))->shouldBeCalledOnce()->willReturn(
+        ))->shouldBeCalledTimes(2)->willReturn(
             $resolvedContent = new Content('some-content', 'AnotherContent', 'rawContent', 'markdown', null, null, [
                 'path' => '/workspace/project/other-contents/another-content.md',
             ])
         );
 
-        $urlGenerator->resolveUrl($resolvedContent)->shouldBeCalledOnce()->willReturn('/other-contents-route-path/another-contents');
+        $urlGenerator->resolveUrl($resolvedContent)->shouldBeCalledTimes(2)->willReturn('/other-contents-route-path/another-contents');
 
         $processor->__invoke($data, \stdClass::class, $currentContent);
 
@@ -65,6 +66,7 @@ class ResolveContentLinksProcessorTest extends TestCase
                 <a href="//external.com">Don't change this</a>
                 <a href="#anchor">Don't change this</a>
                 <a href="/other-contents-route-path/another-contents">Another content</a>
+                <a href="/other-contents-route-path/another-contents#some-anchor">Another content with anchor</a>
             </body>
             HTML,
             $data['content']

--- a/tests/fixtures/app/content/authors/john.doe.md
+++ b/tests/fixtures/app/content/authors/john.doe.md
@@ -2,5 +2,6 @@
 lastname: Doe
 firstname: John
 nickname: the-unknown
+core: false
 tags: []
 ---

--- a/tests/fixtures/app/content/authors/ogi.md
+++ b/tests/fixtures/app/content/authors/ogi.md
@@ -2,6 +2,7 @@
 lastname: Steinhausser
 firstname: Maxime
 nickname: ogi
+core: true
 tags: ["symfony", "cooking"]
 ---
 

--- a/tests/fixtures/app/content/authors/tom32i.md
+++ b/tests/fixtures/app/content/authors/tom32i.md
@@ -2,6 +2,7 @@
 lastname: Jarrand
 firstname: Thomas
 nickname: tom32i
+core: true
 tags: ["symfony", "cooking"]
 ---
 

--- a/tests/fixtures/app/content/recipes/ogito.md
+++ b/tests/fixtures/app/content/recipes/ogito.md
@@ -13,6 +13,7 @@ Learn how to make an Ogito with the following recipe.
 Also see the [famous cheesecake recipe](cheesecake.md) for more yum!
 
 Cheers [Ogi](../authors/ogi.md) for this recipe.
+Check his [other recipes](../authors/ogi.md#recipes).
 
 ## First step
 

--- a/tests/fixtures/app/src/Model/Author.php
+++ b/tests/fixtures/app/src/Model/Author.php
@@ -15,5 +15,6 @@ class Author
     public string $lastname;
     public string $nickname;
     public array $tags;
+    public bool $core = false;
     public \DateTimeInterface $lastModified;
 }

--- a/tests/fixtures/app/src/Model/Recipe.php
+++ b/tests/fixtures/app/src/Model/Recipe.php
@@ -8,7 +8,7 @@
 
 namespace App\Model;
 
-use Stenope\Bundle\TableOfContent\Headline;
+use Stenope\Bundle\TableOfContent\TableOfContent;
 
 class Recipe
 {
@@ -16,8 +16,7 @@ class Recipe
     public ?string $description = null;
     public string $slug;
     public string $content;
-    /** @var Headline[] */
-    public array $tableOfContent = [];
+    public ?TableOfContent $tableOfContent = null;
     public array $authors;
     public array $tags;
     public \DateTimeInterface $date;


### PR DESCRIPTION
Introduce a new `debug:stenope:content` that'll be useful in multiple ways, to debug, list, filter and inspect contents managed by Stenope:

## List

```bash
bin/console debug:stenope:content "App\Model\Page"
```

![Capture d’écran 2021-05-28 à 16 40 01](https://user-images.githubusercontent.com/2211145/120000690-5fba9480-bfd3-11eb-957a-db473f718fd6.png)


## Show

```bash
bin/console debug:stenope:content "App\Model\Index" README
```

![Capture d’écran 2021-05-28 à 16 37 51](https://user-images.githubusercontent.com/2211145/120000413-110cfa80-bfd3-11eb-83dc-67e0d7298359.png)

(change verbosity to display more)

## Order & Filter

```bash
bin/console debug:stenope:content "App\Model\Article" \
   --filter="not:outdated" \
   --filter="slug contains:rebranding" \
   --order="desc:date"
```

![Capture d’écran 2021-05-28 à 16 37 03](https://user-images.githubusercontent.com/2211145/120000280-f33f9580-bfd2-11eb-9ef2-1c70fe6c91d3.png)

---

There are some minor improvments / changes included in this PR as well:
- handle fragment (anchors) when linking content between them ([see how we reference another document with an anchor](https://github.com/StenopePHP/Stenope/pull/97/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58) in the documentation changes in this PR)
- added the ability to provide a filter function for a specific property (it allows the `--filter=field contains:text` feature exposed in the command)
- added the `TableOfContent` class. Small BC break (change your typehints from `Headline[]` to `TableOfContent`), but it allows to dump a simpler representation of the TOC when inspecting a content in non-verbose mode. It may also be useful later in case we need to introduce more data/config inside the TOC.
- `ContentManager::getContents` now returns the slugs as keys

### TODO

- [x] Add some functional tests for the debug command 
- [x] Add unit & functional tests for resolving links with anchors
- [x] Add unit tests for filtering with a callable for a specific property
- [x] Add tests to reflect the keys for `ContentManager::getContents`
- Later: interactively ask the class if not provided
- Later: allow partial classname if no conflict and ask between matches otherwise
- Later: dedicated & more powerful parser classes for orders & filters