### PR TITLE
Use Symfony's ExpressionLanguage component for filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload": {
         "psr-4": {
             "Stenope\\Bundle\\": "src"
-        }
+        },
+        "files": [
+            "src/ExpressionLanguage/exprs.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -60,6 +63,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^0.12.32",
         "symfony/browser-kit": "^5.1",
+        "symfony/expression-language": "^5.1",
         "symfony/framework-bundle": "^5.1",
         "symfony/phpunit-bridge": "^5.1",
         "symfony/twig-bridge": "^5.1",

--- a/config/services.php
+++ b/config/services.php
@@ -21,6 +21,7 @@ use Stenope\Bundle\Decoder\MarkdownDecoder;
 use Stenope\Bundle\DependencyInjection\tags;
 use Stenope\Bundle\EventListener\Informator;
 use Stenope\Bundle\EventListener\SitemapListener;
+use Stenope\Bundle\ExpressionLanguage\ExpressionLanguage;
 use Stenope\Bundle\Highlighter\Prism;
 use Stenope\Bundle\Highlighter\Pygments;
 use Stenope\Bundle\HttpKernel\Controller\ArgumentResolver\ContentArgumentResolver;
@@ -62,10 +63,11 @@ return static function (ContainerConfigurator $container): void {
         ->set(ContentManager::class)->args([
             '$decoder' => service('serializer'),
             '$denormalizer' => service('serializer'),
-            '$propertyAccessor' => service('property_accessor'),
             '$crawlers' => service(HtmlCrawlerManagerInterface::class),
             '$contentProviders' => tagged_iterator(tags\content_provider),
             '$processors' => tagged_iterator(tags\content_processor),
+            '$propertyAccessor' => service('property_accessor'),
+            '$expressionLanguage' => service(ExpressionLanguage::class)->nullOnInvalid(),
             '$stopwatch' => service('debug.stopwatch')->nullOnInvalid(),
         ])
 
@@ -79,6 +81,11 @@ return static function (ContainerConfigurator $container): void {
             '$stopwatch' => service('stenope.build.stopwatch'),
         ])
         ->tag('console.command', ['command' => DebugCommand::getDefaultName()])
+
+        // Expression Language
+        ->set(ExpressionLanguage::class)->args([
+            '$providers' => tagged_iterator(tags\expression_language_provider),
+        ])
 
         // Build
         ->set(BuildCommand::class)->args([

--- a/config/tags.php
+++ b/config/tags.php
@@ -11,3 +11,4 @@ namespace Stenope\Bundle\DependencyInjection\tags;
 const content_processor = 'stenope.processor';
 const content_provider = 'stenope.content_provider';
 const content_provider_factory = 'stenope.content_provider_factory';
+const expression_language_provider = 'stenope.expression_language_provider';

--- a/doc/app/assets/styles/_admonitions.scss
+++ b/doc/app/assets/styles/_admonitions.scss
@@ -1,0 +1,48 @@
+.admonition {
+  margin: 15px 0;
+  background-color: lighten($color-bg-light, 30);
+
+  .admonition-title {
+    color: transparentize($color-text, 0.5);
+    background-color: lighten($color-bg-light, 25);
+  }
+
+  p {
+    padding: 10px;
+    margin: 0;
+    color: transparentize($color-text, 0.3);
+  }
+
+  &.warning {
+    background-color: lighten($color-warning, 30);
+
+    .admonition-title {
+      color: $color-warning;
+      background-color: lighten($color-warning, 25);
+    }
+
+    p {
+      color: $color-warning;
+    }
+  }
+
+  &.note {
+    background-color: lighten($color-info, 40);
+
+    .admonition-title {
+      color: $color-info;
+      background-color: lighten($color-info, 35);
+    }
+
+    p {
+      color: $color-info;
+    }
+  }
+
+  .admonition-title {
+    padding: 10px;
+    text-transform: capitalize;
+    font-weight: bold;
+    margin: 0;
+  }
+}

--- a/doc/app/assets/styles/_variables.scss
+++ b/doc/app/assets/styles/_variables.scss
@@ -8,6 +8,10 @@ $color-tertiary: #f4f5f6;
 $color-quaternary: #d1d1d1;
 $color-quinary: #e1e1e1;
 
+$color-bg-light: #a7a7a7;
+$color-warning: #ba934f;
+$color-info: #4f98a3;
+
 /* Size */
 $gutter: 2rem;
 

--- a/doc/app/assets/styles/style.scss
+++ b/doc/app/assets/styles/style.scss
@@ -3,6 +3,7 @@
 
 @import '~milligram/src/milligram';
 
+@import './admonitions';
 @import './layout';
 @import './navigation';
 @import './code';

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -38,7 +38,7 @@ bin/console debug:stenope:content [options] [--] <class> [<id>]
 E.g:
 
 ```shell
-bin/console debug:stenope:content "App\Model\Article" --filter="not:outdated" --filter="slug contains:symfony" --order="desc:publishedAt"
+bin/console debug:stenope:content "App\Model\Article" --filter='not _.outdated' --filter='contains(_.slug, "symfony")' --order="desc:publishedAt"
 ```
 
 ```shell

--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -208,6 +208,35 @@ $tagedMobileArticles = $this->manager->getContents(
 );
 ```
 
+#### An ExpressionLanguage expression
+
+```php
+use function Stenope\Bundle\ExpressionLanguage\expr;
+
+$tagedMobileArticles = $this->manager->getContents(
+    Article::class,
+    null,
+    expr('"mobile" in _.tags')
+);
+```
+
+See the [ExpressionLanguage syntax](https://symfony.com/doc/current/components/expression_language/syntax.html).
+You may also want to extend the expression language capabilities for your own contents by [registering a custom expression provider](https://symfony.com/doc/current/components/expression_language/extending.html#using-expression-providers) tagged with `stenope.expression_language_provider`.
+
+Built-in functions are:
+
+- date
+- datetime
+- upper
+- lower
+- contains
+- starts_with
+- ends_with
+
+!!! Note
+    `expr` accepts multiple expressions it'll combine using `and`.  
+     Use `exprOr` to combine expressions using `or`.
+
 ## Debug
 
 See [CLI - Debug](./cli.md#debug)

--- a/doc/twig.md
+++ b/doc/twig.md
@@ -9,6 +9,8 @@ from your templates.
 | -- | -- |
 | `content_get(type, id)` | Fetch a specific content |
 | `content_list(type, sortBy, filterBy)` |  List all contents for a given type |
+| `content_expr(...exprs)` |  Allow to build an expression to filter content with `content_list` |
+| `content_expr_or(...exprs)` |  Allow to build an expression combined with `or` to filter content with `content_list` |
 
 ## Usage
 

--- a/src/DependencyInjection/StenopeExtension.php
+++ b/src/DependencyInjection/StenopeExtension.php
@@ -11,6 +11,7 @@ namespace Stenope\Bundle\DependencyInjection;
 use Stenope\Bundle\Behaviour\HtmlCrawlerManagerInterface;
 use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Builder;
+use Stenope\Bundle\ExpressionLanguage\ExpressionLanguage as StenopeExpressionLanguage;
 use Stenope\Bundle\Provider\ContentProviderInterface;
 use Stenope\Bundle\Provider\Factory\ContentProviderFactory;
 use Stenope\Bundle\Provider\Factory\ContentProviderFactoryInterface;
@@ -22,6 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class StenopeExtension extends Extension
 {
@@ -45,6 +47,10 @@ class StenopeExtension extends Extension
 
         $this->processProviders($container, $config['providers']);
         $this->processLinkResolvers($container, $config['resolve_links']);
+
+        if (!class_exists(ExpressionLanguage::class)) {
+            $container->removeDefinition(StenopeExpressionLanguage::class);
+        }
     }
 
     public function getNamespace()

--- a/src/ExpressionLanguage/Expression.php
+++ b/src/ExpressionLanguage/Expression.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\Expression as BaseExpression;
+
+if (!class_exists(\Symfony\Component\ExpressionLanguage\ExpressionLanguage::class)) {
+    throw new \LogicException(sprintf('You must install the Symfony ExpressionLanguage component ("symfony/expression-language") in order to use the "%s" class.', Expression::class));
+}
+
+final class Expression extends BaseExpression
+{
+    public static function combineAnd(string ...$exprs): self
+    {
+        if (\count($exprs) === 1) {
+            return new Expression(...$exprs);
+        }
+
+        return new self(implode(' and ', array_map(static fn ($e) => sprintf('(%s)', $e), $exprs)));
+    }
+
+    public static function combineOr(string ...$exprs): self
+    {
+        if (\count($exprs) === 1) {
+            return new Expression(...$exprs);
+        }
+
+        return new self(implode(' or ', array_map(static fn ($e) => sprintf('(%s)', $e), $exprs)));
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+}

--- a/src/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/ExpressionLanguage/ExpressionLanguage.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\ExpressionLanguage;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+
+class ExpressionLanguage extends BaseExpressionLanguage
+{
+    /**
+     * @param iterable<ExpressionFunctionProviderInterface> $providers
+     */
+    public function __construct(iterable $providers = [], ?CacheItemPoolInterface $cache = null)
+    {
+        parent::__construct($cache, [new ExpressionLanguageProvider($providers)]);
+    }
+}

--- a/src/ExpressionLanguage/ExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/ExpressionLanguageProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * @internal
+ */
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    /** @var iterable<ExpressionFunctionProviderInterface> */
+    private iterable $providers;
+
+    public function __construct(iterable $providers = [])
+    {
+        $this->providers = $providers;
+    }
+
+    public function getFunctions()
+    {
+        // prepend the default functions to let users override these easily:
+        yield from [
+            new ExpressionFunction('date', function ($arg) {
+                return sprintf('(new \DateTimeImmutable(%s))->setTime(0, 0)', $arg);
+            }, function (array $variables, $value) {
+                return (new \DateTimeImmutable($value))->setTime(0, 0);
+            }),
+            new ExpressionFunction('datetime', function ($arg) {
+                return sprintf('new \DateTimeImmutable(%s)', $arg);
+            }, function (array $variables, $value) {
+                return new \DateTimeImmutable($value);
+            }),
+            ExpressionFunction::fromPhp('strtoupper', 'upper'),
+            ExpressionFunction::fromPhp('strtolower', 'lower'),
+            ExpressionFunction::fromPhp('str_contains', 'contains'),
+            ExpressionFunction::fromPhp('str_starts_with', 'starts_with'),
+            ExpressionFunction::fromPhp('str_ends_with', 'ends_with'),
+        ];
+
+        foreach ($this->providers as $provider) {
+            yield from $provider->getFunctions();
+        }
+    }
+}

--- a/src/ExpressionLanguage/exprs.php
+++ b/src/ExpressionLanguage/exprs.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\ExpressionLanguage;
+
+function expr(string ...$exprs): Expression
+{
+    return Expression::combineAnd(...$exprs);
+}
+
+function exprOr(string ...$exprs): Expression
+{
+    return Expression::combineOr(...$exprs);
+}

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -18,6 +18,8 @@ class ContentExtension extends AbstractExtension
         return [
             new TwigFunction('content_get', [ContentRuntime::class, 'getContent']),
             new TwigFunction('content_list', [ContentRuntime::class, 'listContents']),
+            new TwigFunction('content_expr', '\Stenope\Bundle\ExpressionLanguage\expr'),
+            new TwigFunction('content_expr_or', '\Stenope\Bundle\ExpressionLanguage\exprOr'),
         ];
     }
 }

--- a/tests/Unit/ContentManagerTest.php
+++ b/tests/Unit/ContentManagerTest.php
@@ -16,6 +16,7 @@ use Stenope\Bundle\Behaviour\HtmlCrawlerManagerInterface;
 use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Content;
 use Stenope\Bundle\ContentManager;
+use function Stenope\Bundle\ExpressionLanguage\expr;
 use Stenope\Bundle\Provider\ContentProviderInterface;
 use Stenope\Bundle\Provider\ReversibleContentProviderInterface;
 use Stenope\Bundle\ReverseContent\RelativeLinkContext;
@@ -128,6 +129,10 @@ class ContentManagerTest extends TestCase
         self::assertSame([
             'foo2' => 'Foo 2',
         ], $getResults($manager->getContents('App\Foo', null, fn ($foo) => $foo->content === 'Foo 2')), 'filtered by function');
+
+        self::assertSame([
+            'foo2' => 'Foo 2',
+        ], $getResults($manager->getContents('App\Foo', null, expr('_.content === "Foo 2"'))), 'filtered using an expression');
     }
 
     public function testReverseContent(): void

--- a/tests/Unit/ExpressionLanguage/ExpressionTest.php
+++ b/tests/Unit/ExpressionLanguage/ExpressionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Unit\ExpressionLanguage;
+
+use PHPUnit\Framework\TestCase;
+use function Stenope\Bundle\ExpressionLanguage\expr;
+use Stenope\Bundle\ExpressionLanguage\Expression;
+use function Stenope\Bundle\ExpressionLanguage\exprOr;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class ExpressionTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testUnavailableExpressionLanguageHint(): void
+    {
+        ClassExistsMock::register(Expression::class);
+        ClassExistsMock::withMockedClasses([ExpressionLanguage::class => false]);
+
+        try {
+            $this->expectException(\LogicException::class);
+            $this->expectExceptionMessage('You must install the Symfony ExpressionLanguage component ("symfony/expression-language")');
+
+            new Expression('_.foo');
+        } finally {
+            ClassExistsMock::withMockedClasses([ExpressionLanguage::class => true]);
+        }
+    }
+
+    public function testCombineAnd(): void
+    {
+        self::assertSame('(_.active) and (!_.outdated)', (string) Expression::combineAnd('_.active', '!_.outdated'));
+        self::assertSame('(_.active) and (!_.outdated)', (string) expr('_.active', '!_.outdated'));
+    }
+
+    public function testCombineOr(): void
+    {
+        self::assertSame('(!_.active) or (_.outdated)', (string) Expression::combineOr('!_.active', '_.outdated'));
+        self::assertSame('(!_.active) or (_.outdated)', (string) exprOr('!_.active', '_.outdated'));
+    }
+}


### PR DESCRIPTION
Fixes #99. A bit more verbose, but waaay more powerful and extensible.

```bash
  See https://symfony.com/doc/current/components/expression_language/syntax.html
  The current item is referred using "data", "d" or "_":

      php bin/console debug:stenope:content "App\Model\Author" --filter=data.active
      php bin/console debug:stenope:content "App\Model\Author" --filter=d.active
      php bin/console debug:stenope:content "App\Model\Author" --filter=_.active

  Negation:

      php bin/console debug:stenope:content "App\Model\Author" --filter='not d.active'
      php bin/console debug:stenope:content "App\Model\Author" --filter='!d.active'

  Contains:

      php bin/console debug:stenope:content "App\Model\Article" --filter='contains(_.slug, "symfony")'

  You can also use multiple filters at once:

      php bin/console debug:stenope:content "App\Model\Article" \
          --filter='not _.outdated' \
          --filter='contains(_.slug, "dev")' \
          --filter='"symfony" in _.tags' \
          --filter='_.date > date("2021-01-23")'

  Built-in functions are:

  * date
  * datetime
  * upper
  * lower
  * contains
  * starts_with
  * ends_with
```

Expressions can be used to filter using the `ContentManager::getContents` and in Twig as well.
New functions can be added using the `stenope.expression_language_provider` tag.

---

### TODO

- [x] Fix & add more tests