### PR TITLE
Use git last commit date for a file as default last modified date

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -188,7 +188,11 @@ return static function (ContainerConfigurator $container): void {
 
     // Tagged processors:
     $container->services()->defaults()->tag(tags\content_processor)
-        ->set(LastModifiedProcessor::class)
+        ->set(LastModifiedProcessor::class)->args([
+            '$property' => 'lastModified',
+            '$gitPath' => 'git',
+            '$logger' => service(LoggerInterface::class)->nullOnInvalid(),
+        ])
         ->set(SlugProcessor::class)
         ->set(HtmlIdProcessor::class)
             ->args([

--- a/config/services.php
+++ b/config/services.php
@@ -42,6 +42,7 @@ use Stenope\Bundle\Routing\RouteInfoCollection;
 use Stenope\Bundle\Routing\UrlGenerator;
 use Stenope\Bundle\Serializer\Normalizer\SkippingInstantiatedObjectDenormalizer;
 use Stenope\Bundle\Service\AssetUtils;
+use Stenope\Bundle\Service\Git\LastModifiedFetcher;
 use Stenope\Bundle\Service\NaiveHtmlCrawlerManager;
 use Stenope\Bundle\Service\Parsedown;
 use Stenope\Bundle\Service\SharedHtmlCrawlerManager;
@@ -190,8 +191,10 @@ return static function (ContainerConfigurator $container): void {
     $container->services()->defaults()->tag(tags\content_processor)
         ->set(LastModifiedProcessor::class)->args([
             '$property' => 'lastModified',
-            '$gitPath' => 'git',
-            '$logger' => service(LoggerInterface::class)->nullOnInvalid(),
+            '$gitLastModified' => inline_service(LastModifiedFetcher::class)->args([
+                '$gitPath' => 'git',
+                '$logger' => service(LoggerInterface::class)->nullOnInvalid(),
+            ]),
         ])
         ->set(SlugProcessor::class)
         ->set(HtmlIdProcessor::class)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
 
     excludes_analyse:
         - tests/fixtures/app/var/
+        - tests/fixtures/Unit/Service/Git/bin
 
     level: 1
 

--- a/src/Content.php
+++ b/src/Content.php
@@ -14,8 +14,8 @@ final class Content
     private string $type;
     private string $rawContent;
     private string $format;
-    private ?\DateTime $lastModified;
-    private ?\DateTime $createdAt;
+    private ?\DateTimeImmutable $lastModified;
+    private ?\DateTimeImmutable $createdAt;
     private array $metadata;
 
     public function __construct(
@@ -23,8 +23,8 @@ final class Content
         string $type,
         string $rawContent,
         string $format,
-        ?\DateTime $lastModified = null,
-        ?\DateTime $createdAt = null,
+        ?\DateTimeImmutable $lastModified = null,
+        ?\DateTimeImmutable $createdAt = null,
         array $metadata = []
     ) {
         $this->slug = $slug;
@@ -51,12 +51,12 @@ final class Content
         return $this->rawContent;
     }
 
-    public function getLastModified(): ?\DateTime
+    public function getLastModified(): ?\DateTimeImmutable
     {
         return $this->lastModified;
     }
 
-    public function getCreatedAt(): ?\DateTime
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }

--- a/src/Processor/LastModifiedProcessor.php
+++ b/src/Processor/LastModifiedProcessor.php
@@ -8,28 +8,88 @@
 
 namespace Stenope\Bundle\Processor;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Content;
+use Stenope\Bundle\Provider\Factory\LocalFilesystemProviderFactory;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
 
 /**
- * Set a "LastModified" property based on file date
+ * Set a "LastModified" property based on the last modified date set by the provider.
+ * E.g, for the {@see LocalFilesystemProvider}, the file mtime on the filesystem.
+ *
+ * If available, for local files, it'll use Git to get the last commit date for this file.
  */
 class LastModifiedProcessor implements ProcessorInterface
 {
     private string $property;
+    /** Git executable path on the system / PATH used to get the last commit date for the file, or null to disable. */
+    private ?string $gitPath;
+    private LoggerInterface $logger;
 
-    public function __construct(string $property = 'lastModified')
-    {
+    private static ?bool $gitAvailable = null;
+
+    public function __construct(
+        string $property = 'lastModified',
+        ?string $gitPath = 'git',
+        ?LoggerInterface $logger = null
+    ) {
         $this->property = $property;
+        $this->gitPath = $gitPath;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function __invoke(array &$data, Content $content): void
     {
         if (\array_key_exists($this->property, $data)) {
-            // Last modified already set.
+            // Last modified already set (even if explicitly set as null).
             return;
         }
 
-        $data[$this->property] = $content->getLastModified() ? $content->getLastModified()->format(\DateTimeInterface::RFC3339) : null;
+        $data[$this->property] = $content->getLastModified();
+
+        if (LocalFilesystemProviderFactory::TYPE !== ($content->getMetadata()['provider'] ?? null)) {
+            // Won't attempt with a non local filesystem content.
+            return;
+        }
+
+        if (null === $this->gitPath || false === self::$gitAvailable) {
+            // Don't go further if the git command is not available or the git feature is disabled
+            return;
+        }
+
+        if (null === self::$gitAvailable) {
+            // Check once if the git command is available
+            $process = new Process([$this->gitPath, '--version']);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                self::$gitAvailable = false;
+
+                $this->logger->notice('Git was not found at path "{gitPath}". Check the binary path is correct or part of your PATH.', [
+                    'gitPath' => $this->gitPath,
+                    'output' => $process->getOutput(),
+                    'err_output' => $process->getErrorOutput(),
+                ]);
+
+                return;
+            }
+
+            self::$gitAvailable = true;
+        }
+
+        $filePath = $content->getMetadata()['path'];
+        $process = new Process([$this->gitPath, 'log', '-1', '--format=%cd', '--date=iso', $filePath]);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        if ($output = $process->getOutput()) {
+            $data[$this->property] = new \DateTime($output);
+        }
     }
 }

--- a/src/Processor/LastModifiedProcessor.php
+++ b/src/Processor/LastModifiedProcessor.php
@@ -89,7 +89,7 @@ class LastModifiedProcessor implements ProcessorInterface
         }
 
         if ($output = $process->getOutput()) {
-            $data[$this->property] = new \DateTime($output);
+            $data[$this->property] = new \DateTimeImmutable($output);
         }
     }
 }

--- a/src/Provider/LocalFilesystemProvider.php
+++ b/src/Provider/LocalFilesystemProvider.php
@@ -101,7 +101,7 @@ class LocalFilesystemProvider implements ReversibleContentProviderInterface
             $this->supportedClass,
             file_get_contents($file->getPathname()),
             self::getFormat($file),
-            new \DateTime("@{$file->getMTime()}"),
+            new \DateTimeImmutable("@{$file->getMTime()}"),
             null,
             [
                 'path' => $file->getRealPath(),

--- a/src/Provider/LocalFilesystemProvider.php
+++ b/src/Provider/LocalFilesystemProvider.php
@@ -131,6 +131,7 @@ class LocalFilesystemProvider implements ReversibleContentProviderInterface
             ->exclude($excludedDirs)
             ->notPath(array_map(fn ($exclude) => $this->convertPattern($exclude), $excludedPatterns))
             ->path(array_map(fn ($pattern) => $this->convertPattern($pattern), $this->patterns))
+            ->sortByName()
         ;
 
         if ($this->depth) {

--- a/src/Service/Git/LastModifiedFetcher.php
+++ b/src/Service/Git/LastModifiedFetcher.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Service\Git;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\Service\ResetInterface;
+
+class LastModifiedFetcher implements ResetInterface
+{
+    /** Git executable path on the system / PATH used to get the last commit date for the file, or null to disable. */
+    private ?string $gitPath;
+    private LoggerInterface $logger;
+
+    private static ?bool $gitAvailable = null;
+
+    public function __construct(
+        ?string $gitPath = 'git',
+        ?LoggerInterface $logger = null
+    ) {
+        $this->gitPath = $gitPath;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * @throws ProcessFailedException
+     */
+    public function __invoke(string $filePath): ?\DateTimeImmutable
+    {
+        if (null === $this->gitPath || false === self::$gitAvailable) {
+            // Don't go further if the git command is not available or the git feature is disabled
+            return null;
+        }
+
+        $executable = explode(' ', $this->gitPath);
+
+        if (null === self::$gitAvailable) {
+            // Check once if the git command is available
+            $process = new Process([...$executable, '--version']);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                self::$gitAvailable = false;
+
+                $this->logger->warning('Git was not found at path "{gitPath}". Check the binary path is correct or part of your PATH.', [
+                    'gitPath' => $this->gitPath,
+                    'output' => $process->getOutput(),
+                    'err_output' => $process->getErrorOutput(),
+                ]);
+
+                return null;
+            }
+
+            self::$gitAvailable = true;
+        }
+
+        $process = new Process([...$executable, 'log', '-1', '--format=%cd', '--date=iso', $filePath]);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        if ($output = $process->getOutput()) {
+            return new \DateTimeImmutable(trim($output));
+        }
+
+        return null;
+    }
+
+    public function reset(): void
+    {
+        self::$gitAvailable = null;
+    }
+}

--- a/tests/Integration/Command/DebugCommandTest.php
+++ b/tests/Integration/Command/DebugCommandTest.php
@@ -57,9 +57,9 @@ class DebugCommandTest extends KernelTestCase
     {
         yield 'list' => [Author::class,
             <<<TXT
-             * tom32i
              * john.doe
              * ogi
+             * tom32i
             TXT
         ];
 
@@ -89,22 +89,22 @@ class DebugCommandTest extends KernelTestCase
 
         yield 'filter property (data prefix)' => [Author::class,
             <<<TXT
-             * tom32i
              * ogi
+             * tom32i
             TXT
         , ['_.core'], ];
 
         yield 'filter property (d prefix)' => [Author::class,
             <<<TXT
-             * tom32i
              * ogi
+             * tom32i
             TXT
         , ['d.core'], ];
 
         yield 'filter property (_ prefix)' => [Author::class,
             <<<TXT
-             * tom32i
              * ogi
+             * tom32i
             TXT
         , ['_.core'], ];
 
@@ -122,24 +122,24 @@ class DebugCommandTest extends KernelTestCase
 
         yield 'filter contains' => [Author::class,
             <<<TXT
-             * tom32i
              * ogi
+             * tom32i
             TXT
             , ['contains(_.slug, "i")'], ];
 
         yield 'filter dates' => [Recipe::class,
             <<<TXT
-             * tomiritsu
              * ogito
+             * tomiritsu
             TXT
             , ['_.date > date("2019-01-01") and _.date < date("2020-01-01")'], ];
 
         yield 'filter and order' => [Author::class,
             <<<TXT
-             * ogi
              * tom32i
+             * ogi
             TXT
-        , ['_.core'], ['slug'], ];
+        , ['_.core'], ['desc:slug'], ];
 
         yield 'multiple filters' => [Author::class,
             <<<TXT

--- a/tests/Unit/Processor/LastModifiedProcessorTest.php
+++ b/tests/Unit/Processor/LastModifiedProcessorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Unit\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Stenope\Bundle\Content;
+use Stenope\Bundle\Processor\LastModifiedProcessor;
+use Stenope\Bundle\Provider\Factory\LocalFilesystemProviderFactory;
+use Stenope\Bundle\Service\Git\LastModifiedFetcher;
+
+class LastModifiedProcessorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testFromContent(): void
+    {
+        $processor = new LastModifiedProcessor('lastModified');
+
+        $data = [];
+        $content = new Content('slug', 'type', 'content', 'format', new \DateTimeImmutable('2021-06-14 10:25:47 +0200'));
+
+        $processor->__invoke($data, $content);
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $data['lastModified']);
+        self::assertEquals($content->getLastModified(), $data['lastModified']);
+    }
+
+    public function testFromGit(): void
+    {
+        $gitFetcher = $this->prophesize(LastModifiedFetcher::class);
+        $gitFetcher->__invoke(Argument::type('string'))
+            ->willReturn($expectedDate = new \DateTimeImmutable('2021-05-10 10:00:00 +0000'))
+            ->shouldBeCalledOnce()
+        ;
+
+        $processor = new LastModifiedProcessor('lastModified', $gitFetcher->reveal());
+
+        $data = [];
+        $content = new Content('slug', 'type', 'content', 'format', new \DateTimeImmutable('2021-06-14 10:25:47 +0200'), new \DateTimeImmutable(), [
+            'provider' => LocalFilesystemProviderFactory::TYPE,
+            'path' => 'some-path.md',
+        ]);
+
+        $processor->__invoke($data, $content);
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $data['lastModified']);
+        self::assertEquals($expectedDate, $data['lastModified']);
+    }
+
+    public function testWontUseGitOnNonFilesProvider(): void
+    {
+        $gitFetcher = $this->prophesize(LastModifiedFetcher::class);
+        $gitFetcher->__invoke(Argument::type('string'))->shouldNotBeCalled();
+
+        $processor = new LastModifiedProcessor('lastModified', $gitFetcher->reveal());
+
+        $data = [];
+        $content = new Content('slug', 'type', 'content', 'format', new \DateTimeImmutable('2021-06-14 10:25:47 +0200'));
+
+        $processor->__invoke($data, $content);
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $data['lastModified']);
+        self::assertEquals($content->getLastModified(), $data['lastModified']);
+    }
+}

--- a/tests/Unit/Service/Git/LastModifiedFetcherTest.php
+++ b/tests/Unit/Service/Git/LastModifiedFetcherTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Tests\Unit\Service\Git;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+use Stenope\Bundle\Service\Git\LastModifiedFetcher;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+class LastModifiedFetcherTest extends TestCase
+{
+    private static string $php;
+    private static string $executable;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$php = (new PhpExecutableFinder())->find();
+        self::$executable = self::$php . ' ' . FIXTURES_DIR . '/Unit/Service/Git/bin/git.php';
+    }
+
+    public function testDisabled(): void
+    {
+        $fetcher = new LastModifiedFetcher(null);
+        $fetcher->reset();
+
+        self::assertNull($fetcher->__invoke('some-fake-path'));
+    }
+
+    public function testUnavailable(): void
+    {
+        $logger = new TestLogger();
+        $fetcher = new LastModifiedFetcher('not-valid-path', $logger);
+        $fetcher->reset();
+
+        self::assertNull($fetcher->__invoke('some-fake-path'));
+        self::assertTrue($logger->hasWarningThatContains('Git was not found at path'));
+        self::assertCount(1, $logger->records);
+
+        self::assertNull($fetcher->__invoke('some-fake-path'));
+        self::assertCount(1, $logger->records, 'Do not attempt to check git avaiulability twice');
+    }
+
+    public function testSuccess(): void
+    {
+        $logger = new TestLogger();
+        $fetcher = new LastModifiedFetcher(self::$executable, $logger);
+        $fetcher->reset();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $date = $fetcher->__invoke('some-fake-path'));
+        self::assertSame('2021-06-14T10:25:47+02:00', $date->format(\DateTimeImmutable::RFC3339));
+    }
+
+    public function testEmpty(): void
+    {
+        $logger = new TestLogger();
+        $fetcher = new LastModifiedFetcher(self::$executable, $logger);
+        $fetcher->reset();
+
+        self::assertNull($fetcher->__invoke('empty'));
+    }
+
+    public function testFailure(): void
+    {
+        $logger = new TestLogger();
+        $fetcher = new LastModifiedFetcher(self::$executable, $logger);
+        $fetcher->reset();
+
+        $this->expectException(ProcessFailedException::class);
+
+        $fetcher->__invoke('fail');
+    }
+}

--- a/tests/fixtures/Unit/Service/Git/bin/git.php
+++ b/tests/fixtures/Unit/Service/Git/bin/git.php
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @see \Stenope\Bundle\Tests\Unit\Service\Git\LastModifiedFetcherTest
+ */
+$path = end($argv);
+
+switch ($path) {
+    case 'fail':
+        exit(1);
+
+    case 'empty':
+        echo '';
+        exit(0);
+
+    default:
+        echo '2021-06-14 10:25:47 +0200' . PHP_EOL;
+        exit(0);
+}


### PR DESCRIPTION
Fixes #98

⚠️ small BC inside => use `\DateTimeInterface` or `\DateTimeImmutable` on your model objects, since this processor now returns a `DateTimeImmutable` now (before was `\DateTime`).