### PR TITLE
Remove property filter as string to promote expressions

### DIFF
--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -184,24 +184,17 @@ $articles = $contentManager->getContents(
 When passing multiple requirements, all must be met:
 
 ```php
-$myDrafts = $this->manager->getContents(
+$myDrafts = $contentManager->getContents(
     Article::class,
     null,
     ['author' => 'ogizanagi', 'draft' => true]
 );
 ```
 
-#### A property name (string)
-
-```php
-// Equivalent to ['active' => true]
-$users = $contentManager->getContents(User::class, 'active');
-```
-
 #### A custom callable supported by the PHP [usort](https://www.php.net/manual/fr/function.usort.php) function
 
 ```php
-$tagedMobileArticles = $this->manager->getContents(
+$tagedMobileArticles = $contentManager->getContents(
     Article::class,
     null,
     fn (Article $article): bool => in_array('mobile', $article->tags)
@@ -213,14 +206,21 @@ $tagedMobileArticles = $this->manager->getContents(
 ```php
 use function Stenope\Bundle\ExpressionLanguage\expr;
 
-$tagedMobileArticles = $this->manager->getContents(
+$tagedMobileArticles = $contentManager->getContents(
     Article::class,
     null,
     expr('"mobile" in _.tags')
 );
+
+// expr() and exprOr() are optional syntax sugar,
+// but you can also provide the expression as a string directly:
+$activeUsers = $contentManager->getContents(User::class, '_.active'); // Equivalent to ['active' => true]
+$activeDevUsers = $contentManager->getContents(User::class, '_.active and _.dev');
 ```
 
-
+!!! Note
+`expr` accepts multiple expressions it'll combine using `and`.  
+Use `exprOr` to combine expressions using `or`.
 
 See the [ExpressionLanguage syntax](https://symfony.com/doc/current/components/expression_language/syntax.html).
 You may also want to extend the expression language capabilities for your own contents by [registering a custom expression provider](https://symfony.com/doc/current/components/expression_language/extending.html#using-expression-providers) tagged with `stenope.expression_language_provider`.
@@ -234,10 +234,6 @@ Built-in functions are:
 - contains
 - starts_with
 - ends_with
-
-!!! Note
-    `expr` accepts multiple expressions it'll combine using `and`.  
-     Use `exprOr` to combine expressions using `or`.
 
 ## Debug
 

--- a/doc/twig.md
+++ b/doc/twig.md
@@ -27,3 +27,11 @@ Get all active job offers:
     <!-- ... -->
 {% endfor %}
 ```
+
+using an expression filter:
+
+```twig
+{% for offer in content_list('App\\Model\\JobOffer', { date: true }, '_.active') %}
+    <!-- ... -->
+{% endfor %}
+```

--- a/src/ContentManager.php
+++ b/src/ContentManager.php
@@ -82,8 +82,9 @@ class ContentManager
      *
      * @param class-string<T>                  $type     Model FQCN e.g. "App/Model/Article"
      * @param string|array|callable            $sortBy   String, array or callable
-     * @param string|array|callable|Expression $filterBy String, array, callable or an {@link Expression} instance to filter out
-     *                                                   with an expression using the ExpressionLanguage component.
+     * @param string|array|callable|Expression $filterBy Array, callable or an {@link Expression} instance / string
+     *                                                   to filter out with an expression using the ExpressionLanguage
+     *                                                   component.
      *
      * @return array<string,T> List of decoded contents with their slug as key
      */
@@ -287,17 +288,12 @@ class ContentManager
             return null;
         }
 
-        if ($filterBy instanceof Expression) {
+        if ($filterBy instanceof Expression || \is_string($filterBy)) {
             return fn ($data) => $this->expressionLanguage->evaluate($filterBy, [
                 'data' => $data,
                 'd' => $data,
                 '_' => $data,
             ]);
-        }
-
-        if (\is_string($filterBy)) {
-            // Check if the property passed as a string is true-ish:
-            return $this->getFilterFunction([$filterBy => true]);
         }
 
         if (\is_callable($filterBy)) {

--- a/tests/Unit/ContentManagerTest.php
+++ b/tests/Unit/ContentManagerTest.php
@@ -133,6 +133,10 @@ class ContentManagerTest extends TestCase
         self::assertSame([
             'foo2' => 'Foo 2',
         ], $getResults($manager->getContents('App\Foo', null, expr('_.content === "Foo 2"'))), 'filtered using an expression');
+
+        self::assertSame([
+            'foo2' => 'Foo 2',
+        ], $getResults($manager->getContents('App\Foo', null, '_.content === "Foo 2"')), 'filtered using an expression directly provided as string');
     }
 
     public function testReverseContent(): void


### PR DESCRIPTION
I suggest to remove this syntax:

```php
$users = $contentManager->getContents(User::class, null, 'active');
```

in favor of expressions:

```php
$users = $contentManager->getContents(User::class, null, '_.active');
```

since:

- it's not much more complex to write
- it allows to enable first-class support for expressions as filters, removing the need to create an `Expression` instance with `expr`/ `exprOr`, and expressions are way more powerful:
  
  ```diff
  -$users = $contentManager->getContents(User::class, null, expr('_.active'));
  +$users = $contentManager->getContents(User::class, null, '_.active');
  ```
- we do not seem to use this syntax since the  begining, but rather use:
  
  ```php
  $users = $contentManager->getContents(User::class, null, ['active' => true]);
  ```

WDYT?