### PR TITLE
Add a ContentManagerInterface

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -16,6 +16,7 @@ use Stenope\Bundle\Builder\Sitemap;
 use Stenope\Bundle\Command\BuildCommand;
 use Stenope\Bundle\Command\DebugCommand;
 use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Stenope\Bundle\Decoder\HtmlDecoder;
 use Stenope\Bundle\Decoder\MarkdownDecoder;
 use Stenope\Bundle\DependencyInjection\tags;
@@ -70,7 +71,8 @@ return static function (ContainerConfigurator $container): void {
             '$propertyAccessor' => service('property_accessor'),
             '$expressionLanguage' => service(ExpressionLanguage::class)->nullOnInvalid(),
             '$stopwatch' => service('debug.stopwatch')->nullOnInvalid(),
-        ])
+        ])->call('setContentManager', [service(ContentManagerInterface::class)])
+        ->alias(ContentManagerInterface::class, ContentManager::class)
 
         // Content providers factories
         ->set(ContentProviderFactory::class)->args(['$factories' => tagged_iterator(tags\content_provider_factory)])
@@ -78,7 +80,7 @@ return static function (ContainerConfigurator $container): void {
 
         // Debug
         ->set(DebugCommand::class)->args([
-            '$manager' => service(ContentManager::class),
+            '$manager' => service(ContentManagerInterface::class),
             '$stopwatch' => service('stenope.build.stopwatch'),
         ])
         ->tag('console.command', ['command' => DebugCommand::getDefaultName()])
@@ -164,7 +166,7 @@ return static function (ContainerConfigurator $container): void {
 
         // Symfony HttpKernel controller argument resolver
         ->set(ContentArgumentResolver::class)
-            ->args(['$contentManager' => service(ContentManager::class)])
+            ->args(['$contentManager' => service(ContentManagerInterface::class)])
             ->tag('controller.argument_value_resolver', [
                 'priority' => 110, // Prior to RequestAttributeValueResolver to resolve from route attribute
             ])
@@ -172,7 +174,7 @@ return static function (ContainerConfigurator $container): void {
         // Twig
         ->set(ContentExtension::class)->tag('twig.extension')
         ->set(ContentRuntime::class)
-            ->args(['$contentManager' => service(ContentManager::class)])
+            ->args(['$contentManager' => service(ContentManagerInterface::class)])
             ->tag('twig.runtime')
 
         // Assets

--- a/doc/app/src/Controller/DocController.php
+++ b/doc/app/src/Controller/DocController.php
@@ -4,15 +4,15 @@ namespace App\Controller;
 
 use App\Model\Index;
 use App\Model\Page;
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
 class DocController extends AbstractController
 {
-    private ContentManager $contentManager;
+    private ContentManagerInterface $contentManager;
 
-    public function __construct(ContentManager $contentManager)
+    public function __construct(ContentManagerInterface $contentManager)
     {
         $this->contentManager = $contentManager;
     }

--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -68,7 +68,7 @@ In your controller (or service):
 namespace App\Controller;
 
 use App\Model\Article;
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -80,7 +80,7 @@ class BlogController extends AbstractController
     /**
      * @Route("/", name="blog")
      */
-    public function index(ContentManager $contentManager)
+    public function index(ContentManagerInterface $contentManager)
     {
         return $this->render(
             'blog/index.html.twig',
@@ -93,7 +93,7 @@ _Note: contents of the same type can very well be writen in different formats._
 
 ### Fetching a specific content
 
-The ContentManager uses slugs to identify your content.
+The content manager uses slugs to identify your content.
 
 The `slug` argument must exactly match the static file name in your content directory.
 
@@ -105,7 +105,7 @@ Example: `$contentManager->getContent(Article::class, 'how-to-train-your-dragon'
 namespace App\Controller;
 
 use App\Model\Article;
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -119,7 +119,7 @@ class BlogController extends AbstractController
     /**
      * @Route("/{slug}", name="article")
      */
-    public function article(ContentManager $contentManager, string $slug)
+    public function article(ContentManagerInterface $contentManager, string $slug)
     {
         return $this->render(
             'blog/article.html.twig',
@@ -194,7 +194,7 @@ $myDrafts = $contentManager->getContents(
 #### A custom callable supported by the PHP [usort](https://www.php.net/manual/fr/function.usort.php) function
 
 ```php
-$tagedMobileArticles = $contentManager->getContents(
+$taggedMobileArticles = $contentManager->getContents(
     Article::class,
     null,
     fn (Article $article): bool => in_array('mobile', $article->tags)
@@ -206,7 +206,7 @@ $tagedMobileArticles = $contentManager->getContents(
 ```php
 use function Stenope\Bundle\ExpressionLanguage\expr;
 
-$tagedMobileArticles = $contentManager->getContents(
+$taggedMobileArticles = $contentManager->getContents(
     Article::class,
     null,
     expr('"mobile" in _.tags')

--- a/doc/twig.md
+++ b/doc/twig.md
@@ -1,6 +1,6 @@
 # Twig integration
 
-Stenope provides a Twig extension to help you interact with the `ContentManager`
+Stenope provides a Twig extension to help you interact with the `ContentManagerInterface`
 from your templates.
 
 ## Functions

--- a/src/Behaviour/ContentManagerAwareInterface.php
+++ b/src/Behaviour/ContentManagerAwareInterface.php
@@ -8,12 +8,12 @@
 
 namespace Stenope\Bundle\Behaviour;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 
 interface ContentManagerAwareInterface
 {
     /**
      * Sets the owning ContentManager object.
      */
-    public function setContentManager(ContentManager $contentManager);
+    public function setContentManager(ContentManagerInterface $contentManager);
 }

--- a/src/Behaviour/ContentManagerAwareTrait.php
+++ b/src/Behaviour/ContentManagerAwareTrait.php
@@ -8,13 +8,16 @@
 
 namespace Stenope\Bundle\Behaviour;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 
+/**
+ * @see ContentManagerAwareInterface
+ */
 trait ContentManagerAwareTrait
 {
-    private ContentManager $contentManager;
+    private ContentManagerInterface $contentManager;
 
-    public function setContentManager(ContentManager $contentManager): void
+    public function setContentManager(ContentManagerInterface $contentManager): void
     {
         $this->contentManager = $contentManager;
     }

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -8,7 +8,7 @@
 
 namespace Stenope\Bundle\Command;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use function Stenope\Bundle\ExpressionLanguage\expr;
 use Stenope\Bundle\ExpressionLanguage\Expression;
 use Stenope\Bundle\TableOfContent\Headline;
@@ -31,10 +31,10 @@ class DebugCommand extends Command
 
     protected static $defaultName = 'debug:stenope:content';
 
-    private ContentManager $manager;
+    private ContentManagerInterface $manager;
     private Stopwatch $stopwatch;
 
-    public function __construct(ContentManager $manager, Stopwatch $stopwatch)
+    public function __construct(ContentManagerInterface $manager, Stopwatch $stopwatch)
     {
         $this->manager = $manager;
         $this->stopwatch = $stopwatch;

--- a/src/ContentManagerInterface.php
+++ b/src/ContentManagerInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle;
+
+use Stenope\Bundle\ReverseContent\Context;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+interface ContentManagerInterface
+{
+    /**
+     * List all content for the given type
+     *
+     * @template T
+     *
+     * @param class-string<T>                  $type     Model FQCN e.g. "App/Model/Article"
+     * @param string|array|callable            $sortBy   String, array or callable
+     * @param string|array|callable|Expression $filterBy Array, callable or an {@link Expression} instance / string
+     *                                                   to filter out with an expression using the ExpressionLanguage
+     *                                                   component.
+     *
+     * @return array<string,T> List of decoded contents with their slug as key
+     */
+    public function getContents(string $type, $sortBy = null, $filterBy = null): array;
+
+    /**
+     * Fetch a specific content
+     *
+     * @template T
+     *
+     * @param class-string<T> $type Model FQCN e.g. "App/Model/Article"
+     * @param string          $id   Unique identifier (slug)
+     *
+     * @return T An object of the given type.
+     */
+    public function getContent(string $type, string $id): object;
+
+    /**
+     * Attempt to reverse resolve a content according to a context.
+     * E.g: attempt to resolve a content relative to another one through its filesystem path.
+     */
+    public function reverseContent(Context $context): ?Content;
+
+    public function supports(string $type): bool;
+}

--- a/src/HttpKernel/Controller/ArgumentResolver/ContentArgumentResolver.php
+++ b/src/HttpKernel/Controller/ArgumentResolver/ContentArgumentResolver.php
@@ -8,16 +8,16 @@
 
 namespace Stenope\Bundle\HttpKernel\Controller\ArgumentResolver;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 class ContentArgumentResolver implements ArgumentValueResolverInterface
 {
-    private ContentManager $contentManager;
+    private ContentManagerInterface $contentManager;
 
-    public function __construct(ContentManager $contentManager)
+    public function __construct(ContentManagerInterface $contentManager)
     {
         $this->contentManager = $contentManager;
     }

--- a/src/ReverseContent/Context.php
+++ b/src/ReverseContent/Context.php
@@ -8,12 +8,12 @@
 
 namespace Stenope\Bundle\ReverseContent;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 
 /**
  * Context from which to resolve a content.
  *
- * @see ContentManager::reverseContent()
+ * @see ContentManagerInterface::reverseContent()
  */
 abstract class Context
 {

--- a/src/Twig/ContentRuntime.php
+++ b/src/Twig/ContentRuntime.php
@@ -8,14 +8,14 @@
 
 namespace Stenope\Bundle\Twig;
 
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class ContentRuntime implements RuntimeExtensionInterface
 {
-    private ContentManager $contentManager;
+    private ContentManagerInterface $contentManager;
 
-    public function __construct(ContentManager $contentManager)
+    public function __construct(ContentManagerInterface $contentManager)
     {
         $this->contentManager = $contentManager;
     }

--- a/tests/Unit/HttpKernel/Controller/ArgumentResolver/ContentArgumentResolverTest.php
+++ b/tests/Unit/HttpKernel/Controller/ArgumentResolver/ContentArgumentResolverTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Stenope\Bundle\Content;
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Stenope\Bundle\HttpKernel\Controller\ArgumentResolver\ContentArgumentResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -23,13 +23,13 @@ class ContentArgumentResolverTest extends TestCase
 
     private ContentArgumentResolver $resolver;
 
-    /** @var ContentManager|ObjectProphecy */
+    /** @var ContentManagerInterface|ObjectProphecy */
     private ObjectProphecy $manager;
 
     protected function setUp(): void
     {
         $this->resolver = new ContentArgumentResolver(
-            ($this->manager = $this->prophesize(ContentManager::class))->reveal()
+            ($this->manager = $this->prophesize(ContentManagerInterface::class))->reveal()
         );
     }
 

--- a/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
+++ b/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
@@ -11,7 +11,7 @@ namespace Stenope\Bundle\Tests\Unit\Processor;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Stenope\Bundle\Content;
-use Stenope\Bundle\ContentManager;
+use Stenope\Bundle\ContentManagerInterface;
 use Stenope\Bundle\Processor\ResolveContentLinksProcessor;
 use Stenope\Bundle\ReverseContent\RelativeLinkContext;
 use Stenope\Bundle\Routing\ContentUrlResolver;
@@ -44,7 +44,7 @@ class ResolveContentLinksProcessorTest extends TestCase
 
         $processor = new ResolveContentLinksProcessor($urlGenerator->reveal(), new NaiveHtmlCrawlerManager());
 
-        $manager = $this->prophesize(ContentManager::class);
+        $manager = $this->prophesize(ContentManagerInterface::class);
         $processor->setContentManager($manager->reveal());
 
         $manager->reverseContent(new RelativeLinkContext(


### PR DESCRIPTION
first need: allowing decoration of the whole content manager

Note: For existing apps, in order for decoration to work as expected, any `ContentManager` typehints and DI injection must be replaced to use the `ContentManagerInterface`, otherwise, your custom code might not be called in every context.

--- 

⚠️ BC Break: 

 The `ContentManagerAwareInterface` now uses `ContentManagerInterface` as its typehints instead of `ContentManager`. That should not be an issue if you use the `ContentManagerAwareTrait` though.