### PR TITLE
[Prism] Reset server on kernel.terminate

### DIFF
--- a/src/Highlighter/Prism.php
+++ b/src/Highlighter/Prism.php
@@ -52,6 +52,7 @@ class Prism implements HighlighterInterface
         }
 
         $this->server->stop();
+        $this->server = null;
         $this->input->close();
     }
 


### PR DESCRIPTION
Fixes:

```bash
In Process.php line 1292:

  [Exception]
  Cannot rewind a generator that was already run

Exception trace:
  at app/vendor/symfony/process/Process.php:1292
 IteratorIterator->rewind() at app/vendor/symfony/process/Process.php:1292
 Symfony\Component\Process\Process->getDescriptors() at app/vendor/symfony/process/Process.php:307
 Symfony\Component\Process\Process->start() at app/vendor/stenope/stenope/src/Highlighter/Prism.php:44
```