### PR TITLE
Workaround DomCrawler UTF-8 issue

### DIFF
--- a/src/Behaviour/HtmlCrawlerManagerInterface.php
+++ b/src/Behaviour/HtmlCrawlerManagerInterface.php
@@ -11,6 +11,10 @@ namespace Stenope\Bundle\Behaviour;
 use Stenope\Bundle\Content;
 use Symfony\Component\DomCrawler\Crawler;
 
+/**
+ * Manager for getting an HTML crawler instance for HTML content properties,
+ * meant to be rendered inside a page.
+ */
 interface HtmlCrawlerManagerInterface
 {
     /**

--- a/src/Decoder/MarkdownDecoder.php
+++ b/src/Decoder/MarkdownDecoder.php
@@ -49,11 +49,11 @@ class MarkdownDecoder implements DecoderInterface
         if ($start === 0 && $stop) {
             return array_merge(
                 $this->parseYaml(substr($content, $start + $length, $stop - $length)),
-                ['content' => $this->markdownify(substr($content, $stop + $length))]
+                ['content' => $this->markdownToHtml(substr($content, $stop + $length))]
             );
         }
 
-        return ['content' => $this->markdownify($content)];
+        return ['content' => $this->markdownToHtml($content)];
     }
 
     /**
@@ -69,10 +69,7 @@ class MarkdownDecoder implements DecoderInterface
         return Yaml::parse($data, true);
     }
 
-    /**
-     * Parse Mardown to return HTML
-     */
-    private function markdownify(string $data): string
+    private function markdownToHtml(string $data): string
     {
         return $this->parser->parse($data);
     }

--- a/src/Service/CrawlerManagerTrait.php
+++ b/src/Service/CrawlerManagerTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Stenope\Bundle\Service;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * @internal
+ */
+trait CrawlerManagerTrait
+{
+    /**
+     * Extracts the raw HTML content from the body tag if available,
+     * avoiding to return the encapsulating head, meta and body tags,
+     * which are useless to render HTML content as part of an existing page.
+     */
+    private function getRawHtmlContent(Crawler $crawler): string
+    {
+        if (1 === ($body = $crawler->filter('body'))->count()) {
+            return trim($body->html());
+        }
+
+        return trim($crawler->html());
+    }
+
+    private function createCrawler(string $html): ?Crawler
+    {
+        $html = trim($html);
+        $crawler = new Crawler($html);
+
+        try {
+            // Pre-check the content is valid HTML
+            $crawler->html();
+        } catch (\Exception $e) {
+            // Content is not valid HTML.
+            return null;
+        }
+
+        if (0 === $crawler->filter('meta[charset]')->count()) {
+            // https://github.com/symfony/symfony/pull/46212
+            // Let's assume the parsed contents will always be HTML5 with UTF-8 charset
+            // and explicitly add the doctype and charset meta tag,
+            // so that it can be properly parsed by Symfony's Crawler:
+            $crawler = new Crawler(<<<HTML
+                <!DOCTYPE html>
+                <html>
+                    <head>
+                        <meta charset="UTF-8" />
+                    </head>
+                    <body>
+                        $html
+                    </body>
+                </html>
+                HTML
+            );
+        }
+
+        return $crawler;
+    }
+}

--- a/src/Service/NaiveHtmlCrawlerManager.php
+++ b/src/Service/NaiveHtmlCrawlerManager.php
@@ -14,6 +14,11 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class NaiveHtmlCrawlerManager implements HtmlCrawlerManagerInterface
 {
+    use CrawlerManagerTrait;
+
+    /**
+     * @var array<string,array<string,Crawler>>
+     */
     private array $crawlers = [];
 
     public function get(Content $content, array &$data, string $property): ?Crawler
@@ -46,24 +51,10 @@ class NaiveHtmlCrawlerManager implements HtmlCrawlerManagerInterface
     {
         foreach ($this->crawlers as $key => $crawlers) {
             foreach ($crawlers as $property => $crawler) {
-                $data[$property] = $crawler->html();
+                $data[$property] = $this->getRawHtmlContent($crawler);
             }
         }
 
         $this->crawlers = [];
-    }
-
-    public function createCrawler(string $html): ?Crawler
-    {
-        $crawler = new Crawler($html);
-
-        try {
-            $crawler->html();
-        } catch (\Exception $e) {
-            // Content is not valid HTML.
-            return null;
-        }
-
-        return $crawler;
     }
 }

--- a/src/Service/SharedHtmlCrawlerManager.php
+++ b/src/Service/SharedHtmlCrawlerManager.php
@@ -14,6 +14,8 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class SharedHtmlCrawlerManager implements HtmlCrawlerManagerInterface
 {
+    use CrawlerManagerTrait;
+
     private array $crawlers = [];
 
     public function get(Content $content, array &$data, string $property): ?Crawler
@@ -51,23 +53,9 @@ class SharedHtmlCrawlerManager implements HtmlCrawlerManagerInterface
         }
 
         foreach ($this->crawlers[$key] as $property => $crawler) {
-            $data[$property] = $crawler->html();
+            $data[$property] = $this->getRawHtmlContent($crawler);
         }
 
         unset($this->crawlers[$key]);
-    }
-
-    public function createCrawler(string $content): ?Crawler
-    {
-        $crawler = new Crawler($content);
-
-        try {
-            $crawler->html();
-        } catch (\Exception $e) {
-            // Content is not valid HTML.
-            return null;
-        }
-
-        return $crawler;
     }
 }

--- a/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
+++ b/tests/Unit/Processor/ResolveContentLinksProcessorTest.php
@@ -16,6 +16,7 @@ use Stenope\Bundle\Processor\ResolveContentLinksProcessor;
 use Stenope\Bundle\ReverseContent\RelativeLinkContext;
 use Stenope\Bundle\Routing\ContentUrlResolver;
 use Stenope\Bundle\Service\NaiveHtmlCrawlerManager;
+use Symfony\Component\DomCrawler\Crawler;
 
 class ResolveContentLinksProcessorTest extends TestCase
 {
@@ -60,6 +61,8 @@ class ResolveContentLinksProcessorTest extends TestCase
 
         $processor->__invoke($data, $currentContent);
 
+        $html = (new Crawler($data['content']))->filter('body')->outerHtml();
+
         self::assertXmlStringEqualsXmlString(<<<HTML
             <body>
                 <a href="/absolute-link">Don't change this</a>
@@ -70,7 +73,7 @@ class ResolveContentLinksProcessorTest extends TestCase
                 <a href="/other-contents-route-path/another-contents#some-anchor">Another content with anchor</a>
             </body>
             HTML,
-            $data['content']
+            $html
         );
     }
 }


### PR DESCRIPTION
by providing the meta charset for any HTML parsed by the crawlers from our manager.

The issue happens since symfony 4.4.39, 5.4.6 and 6.0.6