### PR TITLE
Use AsCommand PHP 8 attribute

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -9,6 +9,7 @@
 namespace Stenope\Bundle\Command;
 
 use Stenope\Bundle\Builder;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Stopwatch\Stopwatch;
 
+#[AsCommand('stenope:build')]
 class BuildCommand extends Command
 {
     use StopwatchHelperTrait;

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -14,6 +14,7 @@ use function Stenope\Bundle\ExpressionLanguage\expr;
 use Stenope\Bundle\ExpressionLanguage\Expression;
 use Stenope\Bundle\TableOfContent\Headline;
 use Stenope\Bundle\TableOfContent\TableOfContent;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Dumper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -26,6 +27,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\VarDumper\Cloner\Stub;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
+#[AsCommand('debug:stenope:content')]
 class DebugCommand extends Command
 {
     use StopwatchHelperTrait;


### PR DESCRIPTION
fixing a 6.1 deprecation about Command::$defaultName usage