### PR TITLE
[BC Break] Remove conflicting expression language custom functions

### DIFF
--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -231,9 +231,6 @@ Built-in functions are:
 - datetime
 - upper
 - lower
-- contains
-- starts_with
-- ends_with
 - keys
 
 ## Debug

--- a/src/ExpressionLanguage/ExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/ExpressionLanguageProvider.php
@@ -40,9 +40,6 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
             }),
             ExpressionFunction::fromPhp('strtoupper', 'upper'),
             ExpressionFunction::fromPhp('strtolower', 'lower'),
-            ExpressionFunction::fromPhp('str_contains', 'contains'),
-            ExpressionFunction::fromPhp('str_starts_with', 'starts_with'),
-            ExpressionFunction::fromPhp('str_ends_with', 'ends_with'),
             ExpressionFunction::fromPhp('array_keys', 'keys'),
         ];
 

--- a/tests/Integration/Command/DebugCommandTest.php
+++ b/tests/Integration/Command/DebugCommandTest.php
@@ -120,13 +120,6 @@ class DebugCommandTest extends KernelTestCase
             TXT
         , ['!_.core'], ];
 
-        yield 'filter contains' => [Author::class,
-            <<<TXT
-             * ogi
-             * tom32i
-            TXT
-            , ['contains(_.slug, "i")'], ];
-
         yield 'filter dates' => [Recipe::class,
             <<<TXT
              * ogito
@@ -145,7 +138,7 @@ class DebugCommandTest extends KernelTestCase
             <<<TXT
              * ogi
             TXT
-        , ['_.core', 'contains(_.slug, "gi")'], ];
+        , ['_.core', '"cooking" in _.tags'], ];
     }
 
     public function testShow(): void

--- a/tests/fixtures/app/content/authors/tom32i.md
+++ b/tests/fixtures/app/content/authors/tom32i.md
@@ -3,7 +3,7 @@ lastname: Jarrand
 firstname: Thomas
 nickname: tom32i
 core: true
-tags: ["symfony", "cooking"]
+tags: ["symfony", "skateboarding"]
 ---
 
 I'm coding on both ends of the HTTP request. ✨


### PR DESCRIPTION
with new 6.1 operators: https://symfony.com/blog/new-in-symfony-6-1-improved-expressionlanguage-syntax

especially the `contains` one which currently conflicts with the operator and produces an exception:

> Symfony\Component\ExpressionLanguage\SyntaxError: Unexpected token "operator" of value "contains" around position 1 for expression contains(article.slug, "foo").

For projects that'll still want to use these function, until installing Symfony 6.1, they can extend the expression language by [registering a custom expression provider](https://symfony.com/doc/current/components/expression_language/extending.html#using-expression-providers) tagged with `stenope.expression_language_provider`:

``` php
class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
{
    public function getFunctions(): iterable
    {
        yield from [
            ExpressionFunction::fromPhp('str_contains', 'contains'),
            ExpressionFunction::fromPhp('str_starts_with', 'starts_with'),
            ExpressionFunction::fromPhp('str_ends_with', 'ends_with'),
        ];
    }
}
```