### PR TITLE
Fixing default URL root for documentation build.

### DIFF
--- a/doc/app/config/packages/routing.yaml
+++ b/doc/app/config/packages/routing.yaml
@@ -4,7 +4,7 @@ framework:
 
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(ROUTER_DEFAULT_URI)%'
 
 when@prod:
     framework:

--- a/doc/app/config/services.yaml
+++ b/doc/app/config/services.yaml
@@ -22,3 +22,7 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    App\Processor\DefaultTocProcessor:
+        tags:
+          - name: 'stenope.processor'
+            priority: '-90' # before the TableOfContentProcessor


### PR DESCRIPTION
Reverting two piece of configuration that were removed (by mistake?) on [commit d090c99](https://github.com/StenopePHP/Stenope/commit/d090c99c868a0247969c103263f9af2bb478695c#).

The routing config causes the link to break on [stenopephp.github.io/stenope/](https://stenopephp.github.io/Stenope/)