### PR TITLE
Check project is a git dir before attempting to use last commit info for files

### DIFF
--- a/src/Service/Git/LastModifiedFetcher.php
+++ b/src/Service/Git/LastModifiedFetcher.php
@@ -68,7 +68,7 @@ class LastModifiedFetcher implements ResetInterface
             if (!$process->isSuccessful()) {
                 self::$gitAvailable = false;
 
-                $this->logger->warning('The current project is not a git repsoitory. Last modified date will not be available using the LastModifiedFetcher.', [
+                $this->logger->warning('The current project is not a git repository. Last modified date will not be available using the LastModifiedFetcher.', [
                     'output' => $process->getOutput(),
                     'err_output' => $process->getErrorOutput(),
                 ]);

--- a/src/Service/Git/LastModifiedFetcher.php
+++ b/src/Service/Git/LastModifiedFetcher.php
@@ -58,6 +58,23 @@ class LastModifiedFetcher implements ResetInterface
 
                 return null;
             }
+        }
+
+        if (null === self::$gitAvailable) {
+            // Check once if the project is a git repository
+            $process = new Process([...$executable, 'rev-parse', '--is-inside-work-tree']);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                self::$gitAvailable = false;
+
+                $this->logger->warning('The current project is not a git repsoitory. Last modified date will not be available using the LastModifiedFetcher.', [
+                    'output' => $process->getOutput(),
+                    'err_output' => $process->getErrorOutput(),
+                ]);
+
+                return null;
+            }
 
             self::$gitAvailable = true;
         }


### PR DESCRIPTION
Prevent getting issues with the processor in these 2 situations:

- trying to execute the app before `git init` (e.g: `composer create-project`)
- cloning the repo without history / from archive
