### PR TITLE
Add processors bundle configuration

### DIFF
--- a/config/processors.php
+++ b/config/processors.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the "StenopePHP/Stenope" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Psr\Log\LoggerInterface;
+use Stenope\Bundle\Behaviour\HtmlCrawlerManagerInterface;
+use Stenope\Bundle\DependencyInjection\tags;
+use Stenope\Bundle\Highlighter\Prism;
+use Stenope\Bundle\Processor\AssetsProcessor;
+use Stenope\Bundle\Processor\CodeHighlightProcessor;
+use Stenope\Bundle\Processor\ExtractTitleFromHtmlContentProcessor;
+use Stenope\Bundle\Processor\HtmlAnchorProcessor;
+use Stenope\Bundle\Processor\HtmlExternalLinksProcessor;
+use Stenope\Bundle\Processor\HtmlIdProcessor;
+use Stenope\Bundle\Processor\LastModifiedProcessor;
+use Stenope\Bundle\Processor\ResolveContentLinksProcessor;
+use Stenope\Bundle\Processor\SlugProcessor;
+use Stenope\Bundle\Processor\TableOfContentProcessor;
+use Stenope\Bundle\Routing\ContentUrlResolver;
+use Stenope\Bundle\Service\AssetUtils;
+use Stenope\Bundle\Service\Git\LastModifiedFetcher;
+use Stenope\Bundle\TableOfContent\CrawlerTableOfContentGenerator;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+require_once __DIR__ . '/tags.php';
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()->defaults()->tag(tags\content_processor)
+        ->set(LastModifiedProcessor::class)->args([
+            '$property' => abstract_arg('lastModified property'),
+            '$gitLastModified' => inline_service(LastModifiedFetcher::class)->args([
+                '$gitPath' => abstract_arg('git path'),
+                '$logger' => service(LoggerInterface::class)->nullOnInvalid(),
+            ]),
+        ])
+        ->set(SlugProcessor::class)->args([
+            '$property' => abstract_arg('slug property'),
+        ])
+        ->set(HtmlIdProcessor::class)
+            ->args([
+                '$slugger' => service(SluggerInterface::class),
+                '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+                '$property' => abstract_arg('content property'),
+            ])
+        ->set(HtmlAnchorProcessor::class)->args([
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$property' => abstract_arg('content property'),
+            '$selector' => abstract_arg('HTML elements selector'),
+        ])
+        ->set(HtmlExternalLinksProcessor::class)->args([
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$property' => abstract_arg('content property'),
+        ])
+        ->set(ExtractTitleFromHtmlContentProcessor::class)->args([
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$titleProperty' => abstract_arg('title property'),
+            '$contentProperty' => abstract_arg('content property'),
+        ])
+        ->set(CodeHighlightProcessor::class)->args([
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$highlighter' => service(Prism::class),
+            '$property' => abstract_arg('content property'),
+        ])
+        ->set(ResolveContentLinksProcessor::class)->args([
+            '$resolver' => service(ContentUrlResolver::class),
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$property' => abstract_arg('content property'),
+        ])
+        ->set(AssetsProcessor::class)->args([
+            '$assetUtils' => service(AssetUtils::class),
+            '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            '$property' => abstract_arg('content property'),
+        ])
+        ->set(TableOfContentProcessor::class)
+            ->args([
+                '$generator' => service(CrawlerTableOfContentGenerator::class),
+                '$tableOfContentProperty' => abstract_arg('table of content property'),
+                '$contentProperty' => abstract_arg('content property'),
+                '$minDepth' => abstract_arg('min depth'),
+                '$maxDepth' => abstract_arg('max depth'),
+                '$crawlers' => service(HtmlCrawlerManagerInterface::class),
+            ])
+            ->tag(tags\content_processor, ['priority' => -100])
+    ;
+};

--- a/config/schema/stenope.xsd
+++ b/config/schema/stenope.xsd
@@ -12,6 +12,7 @@
             <xsd:element name="copy" type="copy_entry" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="provider" type="provider" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="resolve_link" type="resolve_link" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="processors" type="processors_config" minOccurs="0"/>
         </xsd:sequence>
         <xsd:attribute name="build_dir" type="xsd:string"/>
     </xsd:complexType>
@@ -53,5 +54,61 @@
         <xsd:attribute name="depth" type="xsd:string" />
         <!-- custom -->
         <xsd:anyAttribute processContents="lax" />
+    </xsd:complexType>
+
+    <xsd:complexType name="processors_config">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="slug" type="processors.slug"/>
+            <xsd:element name="assets" type="processors.generic"/>
+            <xsd:element name="resolve_content_links" type="processors.generic"/>
+            <xsd:element name="external_links" type="processors.generic"/>
+            <xsd:element name="anchors" type="processors.anchors"/>
+            <xsd:element name="html_title" type="processors.html_title"/>
+            <xsd:element name="html_elements_ids" type="processors.generic"/>
+            <xsd:element name="code_highlight" type="processors.generic"/>
+            <xsd:element name="toc" type="processors.toc"/>
+            <xsd:element name="last_modified" type="processors.last_modified"/>
+        </xsd:choice>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="content_property" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.slug">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="property" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.generic">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.anchors">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="selector" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.html_title">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="property" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.toc">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="property" type="xsd:string"/>
+        <xsd:attribute name="min_depth" type="xsd:integer"/>
+        <xsd:attribute name="max_depth" type="xsd:integer"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.last_modified">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="git" type="processors.last_modified.git"/>
+        </xsd:choice>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="property" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="processors.last_modified.git">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="path" type="xsd:string"/>
     </xsd:complexType>
 </xsd:schema>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -103,6 +103,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addProvidersSection($rootNode);
         $this->addResolveLinksSection($rootNode);
+        $this->addProcessorsSection($rootNode);
 
         return $treeBuilder;
     }
@@ -217,6 +218,125 @@ class Configuration implements ConfigurationInterface
                             // Files provider validation
                             ->ifTrue(static fn ($p) => LocalFilesystemProviderFactory::TYPE === $p['type'] && empty($p['config']['path']))
                             ->thenInvalid('The "path" has to be specified to use the "files" provider')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addProcessorsSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('processors')
+                    ->info('Built-in processors configuration. Disable to unregister all of the preconfigured processors.')
+                    ->canBeDisabled()
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('content_property')
+                            ->info('Key used by default by every processors to access and modify the main text of your contents')
+                            ->defaultValue('content')
+                            ->cannotBeEmpty()
+                        ->end()
+
+                        ->arrayNode('slug')
+                            ->canBeDisabled()
+                            ->children()
+                                ->scalarNode('property')
+                                    ->info('Inject the content slug in a property of your model. See SlugProcessor.')
+                                    ->defaultValue('slug')
+                                    ->cannotBeEmpty()
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('assets')
+                            ->info('Attempt to resolve local assets URLs using the Asset component for images and links. See AssetsProcessor.')
+                            ->canBeDisabled()
+                        ->end()
+
+                        ->arrayNode('resolve_content_links')
+                            ->info('Attempt to resolve relative links between contents using the route declared in config. See ResolveContentLinksProcessor.')
+                            ->canBeDisabled()
+                        ->end()
+
+                        ->arrayNode('external_links')
+                            ->info('Automatically add target="_blank" to external links. See HtmlExternalLinksProcessor.')
+                            ->canBeDisabled()
+                        ->end()
+
+                        ->arrayNode('anchors')
+                            ->canBeDisabled()
+                            ->info('Automatically add anchor links to elements with an id. See HtmlAnchorProcessor.')
+                            ->children()
+                                ->scalarNode('selector')
+                                    ->defaultValue('h1, h2, h3, h4, h5')
+                                    ->cannotBeEmpty()
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('html_title')
+                            ->canBeDisabled()
+                            ->info('Extract a content title from a HTML property by using the first available h1 tag. See ExtractTitleFromHtmlContentProcessor.')
+                            ->children()
+                                ->scalarNode('property')
+                                    ->info('Property where to inject the title in your model')
+                                    ->defaultValue('title')
+                                    ->cannotBeEmpty()
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('html_elements_ids')
+                            ->canBeDisabled()
+                            ->info('Add ids to titles, images and other HTML elements in the content. See HtmlIdProcessor.')
+                        ->end()
+
+                        ->arrayNode('code_highlight')
+                            ->canBeDisabled()
+                            ->info('Enabled the syntax highlighting for code blocks using Prism.js. See CodeHighlightProcessor.')
+                        ->end()
+
+                        ->arrayNode('toc')
+                            ->canBeDisabled()
+                            ->info('Build a table of content from the HTML titles. See TableOfContentProcessor.')
+                            ->children()
+                                ->scalarNode('property')
+                                    ->info('Property used to configure and inject the TableOfContent object in your model')
+                                    ->defaultValue('tableOfContent')
+                                    ->cannotBeEmpty()
+                                ->end()
+                                ->integerNode('min_depth')
+                                    ->defaultValue(2)
+                                ->end()
+                                ->integerNode('max_depth')
+                                    ->defaultValue(6)
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('last_modified')
+                            ->canBeDisabled()
+                            ->info('Attempt to fetch and populate the last modified date to a property. See LastModifiedProcessor.')
+                            ->children()
+                                ->scalarNode('property')
+                                    ->info('Property where to inject the last modified date of the content according to its provider.')
+                                    ->defaultValue('lastModified')
+                                    ->cannotBeEmpty()
+                                ->end()
+                                ->arrayNode('git')
+                                    ->canBeDisabled()
+                                    ->info('Whether to attempt using Git to get the last modified date of the content according to commits.')
+                                    ->children()
+                                        ->scalarNode('path')
+                                        ->info('Git binary path to use')
+                                        ->defaultValue('git')
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Processor/AssetsProcessor.php
+++ b/src/Processor/AssetsProcessor.php
@@ -22,8 +22,11 @@ class AssetsProcessor implements ProcessorInterface
     private HtmlCrawlerManagerInterface $crawlers;
     private string $property;
 
-    public function __construct(AssetUtils $assetUtils, HtmlCrawlerManagerInterface $crawlers, string $property = 'content')
-    {
+    public function __construct(
+        AssetUtils $assetUtils,
+        HtmlCrawlerManagerInterface $crawlers,
+        string $property = 'content'
+    ) {
         $this->assetUtils = $assetUtils;
         $this->crawlers = $crawlers;
         $this->property = $property;

--- a/src/Processor/HtmlAnchorProcessor.php
+++ b/src/Processor/HtmlAnchorProcessor.php
@@ -19,11 +19,16 @@ class HtmlAnchorProcessor implements ProcessorInterface
 {
     private HtmlCrawlerManagerInterface $crawlers;
     private string $property;
+    private string $selector;
 
-    public function __construct(HtmlCrawlerManagerInterface $crawlers, string $property = 'content')
-    {
+    public function __construct(
+        HtmlCrawlerManagerInterface $crawlers,
+        string $property = 'content',
+        string $selector = 'h1, h2, h3, h4, h5'
+    ) {
         $this->crawlers = $crawlers;
         $this->property = $property;
+        $this->selector = $selector;
     }
 
     public function __invoke(array &$data, Content $content): void
@@ -38,7 +43,7 @@ class HtmlAnchorProcessor implements ProcessorInterface
             return;
         }
 
-        foreach ($crawler->filter('h1, h2, h3, h4, h5') as $element) {
+        foreach ($crawler->filter($this->selector) as $element) {
             $this->addAnchor($element);
         }
 
@@ -56,7 +61,7 @@ class HtmlAnchorProcessor implements ProcessorInterface
             return;
         }
 
-        $child->appendXML('<a href="#' . $element->getAttribute('id') . '" class="anchor"></a>');
+        $child->appendXML(sprintf('<a href="#%s" class="anchor"></a>', $id));
 
         $element->appendChild($child);
     }

--- a/src/Processor/HtmlIdProcessor.php
+++ b/src/Processor/HtmlIdProcessor.php
@@ -15,7 +15,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
 
 /**
- * Add ids to title in the content
+ * Add ids to HTML elements in the content
  */
 class HtmlIdProcessor implements ProcessorInterface
 {

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -274,6 +274,51 @@ class ConfigurationTest extends TestCase
             'providers' => [],
             'resolve_links' => [],
             'shared_html_crawlers' => false,
+            'processors' => [
+                'enabled' => true,
+                'content_property' => 'content',
+                'slug' => [
+                    'enabled' => true,
+                    'property' => 'slug',
+                ],
+                'assets' => [
+                    'enabled' => true,
+                ],
+                'resolve_content_links' => [
+                    'enabled' => true,
+                ],
+                'external_links' => [
+                    'enabled' => true,
+                ],
+                'anchors' => [
+                    'enabled' => true,
+                    'selector' => 'h1, h2, h3, h4, h5',
+                ],
+                'html_title' => [
+                    'enabled' => true,
+                    'property' => 'title',
+                ],
+                'html_elements_ids' => [
+                    'enabled' => true,
+                ],
+                'code_highlight' => [
+                    'enabled' => true,
+                ],
+                'toc' => [
+                    'enabled' => true,
+                    'property' => 'tableOfContent',
+                    'min_depth' => 2,
+                    'max_depth' => 6,
+                ],
+                'last_modified' => [
+                    'enabled' => true,
+                    'property' => 'lastModified',
+                    'git' => [
+                        'enabled' => true,
+                        'path' => 'git',
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/disabled_processors.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/disabled_processors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors enabled="false" />
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/anchors_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/anchors_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:anchors enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/anchors_selector.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/anchors_selector.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:anchors selector="h1, h2, h4"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/assets_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/assets_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:assets enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/code_highlight_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/code_highlight_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:code_highlight enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/external_links_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/external_links_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:external_links enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_elements_ids_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_elements_ids_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:html_elements_ids enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_title_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_title_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:html_title enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_title_property.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/html_title_property.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:html_title property="documentName"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/last_modified_config.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/last_modified_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:last_modified property="updatedAt">
+                <stenope:git path="/usr/bin/git" />
+            </stenope:last_modified>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/last_modified_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/last_modified_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:last_modified enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/resolve_content_links_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/resolve_content_links_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:resolve_content_links enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/slug_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/slug_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:slug enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/slug_property.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/slug_property.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:slug property="id"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/toc_config.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/toc_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:toc property="toc" min_depth="1" max_depth="3" />
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/toc_disabled.xml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/xml/processors/toc_disabled.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:stenope="http://stenope.com/schema/dic/stenope"
+           xsi:schemaLocation="http://stenope.com/schema/dic/stenope http://stenope.com/schema/dic/stenope/stenope.xsd">
+
+    <stenope:config>
+        <stenope:processors>
+            <stenope:toc enabled="false"/>
+        </stenope:processors>
+    </stenope:config>
+</container>

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/disabled_processors.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/disabled_processors.yaml
@@ -1,0 +1,2 @@
+stenope:
+    processors: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/anchors_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/anchors_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        anchors: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/anchors_selector.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/anchors_selector.yaml
@@ -1,0 +1,4 @@
+stenope:
+    processors:
+        anchors:
+            selector: h1, h2, h4

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/assets_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/assets_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        assets: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/code_highlight_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/code_highlight_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        code_highlight: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/external_links_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/external_links_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        external_links: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_elements_ids_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_elements_ids_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        html_elements_ids: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_title_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_title_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        html_title: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_title_property.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/html_title_property.yaml
@@ -1,0 +1,4 @@
+stenope:
+    processors:
+        html_title:
+            property: documentName

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/last_modified_config.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/last_modified_config.yaml
@@ -1,0 +1,6 @@
+stenope:
+    processors:
+        last_modified:
+            property: updatedAt
+            git:
+                path: /usr/bin/git

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/last_modified_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/last_modified_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        last_modified: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/resolve_content_links_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/resolve_content_links_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        resolve_content_links: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/slug_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/slug_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        slug: false

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/slug_property.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/slug_property.yaml
@@ -1,0 +1,4 @@
+stenope:
+    processors:
+        slug:
+            property: id

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/toc_config.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/toc_config.yaml
@@ -1,0 +1,6 @@
+stenope:
+    processors:
+        toc:
+            property: toc
+            min_depth: 1
+            max_depth: 3

--- a/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/toc_disabled.yaml
+++ b/tests/fixtures/Unit/DependencyInjection/StenopeExtension/yaml/processors/toc_disabled.yaml
@@ -1,0 +1,3 @@
+stenope:
+    processors:
+        toc: false


### PR DESCRIPTION
Allowing to tweaks the defaults and/or disable some of the built-in processors

Fixes #90


### Default config

```shell
$> symfony console debug:config stenope processor

Current configuration for "stenope.processors"
==============================================

enabled: true
content_property: content
slug:
    enabled: true
    property: slug
assets:
    enabled: true
resolve_content_links:
    enabled: true
external_links:
    enabled: true
anchors:
    enabled: true
    selector: 'h1, h2, h3, h4, h5'
html_title:
    enabled: true
    property: title
html_elements_ids:
    enabled: true
code_highlight:
    enabled: true
toc:
    enabled: true
    property: tableOfContent
    min_depth: 2
    max_depth: 6
last_modified:
    enabled: true
    property: lastModified
    git:
        enabled: true
        path: git
```

### Config reference

```shell
$> symfony console config:dump-ref stenope processors
# Default configuration for extension with alias: "stenope" at path "processors"

# Built-in processors configuration. Disable to unregister all of the preconfigured processors.
processors:
    enabled:              true

    # Key used by default by every processors to access and modify the main text of your contents
    content_property:     content
    slug:
        enabled:              true

        # Inject the content slug in a property of your model. See SlugProcessor.
        property:             slug

    # Attempt to resolve local assets URLs using the Asset component for images and links. See AssetsProcessor.
    assets:
        enabled:              true

    # Attempt to resolve relative links between contents using the route declared in config. See ResolveContentLinksProcessor.
    resolve_content_links:
        enabled:              true

    # Automatically add target="_blank" to external links. See HtmlExternalLinksProcessor.
    external_links:
        enabled:              true

    # Automatically add anchor links to elements with an id. See HtmlAnchorProcessor.
    anchors:
        enabled:              true
        selector:             'h1, h2, h3, h4, h5'

    # Extract a content title from a HTML property by using the first available h1 tag. See ExtractTitleFromHtmlContentProcessor.
    html_title:
        enabled:              true

        # Property where to inject the title in your model
        property:             title

    # Add ids to titles, images and other HTML elements in the content. See HtmlIdProcessor.
    html_elements_ids:
        enabled:              true

    # Enabled the syntax highlighting for code blocks using Prism.js. See CodeHighlightProcessor.
    code_highlight:
        enabled:              true

    # Build a table of content from the HTML titles. See TableOfContentProcessor.
    toc:
        enabled:              true

        # Property used to configure and inject the TableOfContent object in your model
        property:             tableOfContent
        min_depth:            2
        max_depth:            6

    # Attempt to fetch and populate the last modified date to a property. See LastModifiedProcessor.
    last_modified:
        enabled:              true

        # Property where to inject the last modified date of the content according to its provider.
        property:             lastModified

        # Whether to attempt using Git to get the last modified date of the content according to commits.
        git:
            enabled:              true

            # Git binary path to use
            path:                 git
```