### PR TITLE
[Builder] Decode URLs before dumping to file

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -440,7 +440,7 @@ class Builder
      */
     private function getFilePath(Request $request, Response $response): array
     {
-        $url = $request->getPathInfo();
+        $url = rawurldecode($request->getPathInfo());
         $info = pathinfo($url);
         $extension = $info['extension'] ?? null;
 

--- a/tests/Integration/BuildTest.php
+++ b/tests/Integration/BuildTest.php
@@ -61,7 +61,7 @@ class BuildTest extends KernelTestCase
         TXT
         );
 
-        $this->assertStringContainsString('[OK] Built 17 pages.', $output);
+        $this->assertStringContainsString('[OK] Built 19 pages.', $output);
 
         /** @var TestLogger $logger */
         $logger = static::getContainer()->get('logger');
@@ -106,6 +106,7 @@ class BuildTest extends KernelTestCase
             'http://localhost/recipes/',
             'http://localhost/recipes/cheesecake',
             'http://localhost/recipes/ogito',
+            'http://localhost/recipes/stockholm%20mule',
             'http://localhost/recipes/tomiritsu',
             'http://localhost/with-noindex',
             'http://localhost/without-noindex',
@@ -129,12 +130,14 @@ class BuildTest extends KernelTestCase
         self::assertDirectoryExists($buildDir . '/recipes');
         self::assertFileExists($buildDir . '/recipes/index.html');
         self::assertFileExists($buildDir . '/recipes/cheesecake/index.html');
+        self::assertFileExists($buildDir . '/recipes/stockholm mule/index.html');
         self::assertFileExists($buildDir . '/recipes/ogito/index.html');
 
         $crawler = new Crawler(file_get_contents($buildDir . '/recipes/index.html'), 'http://localhost/recipes/');
         $links = array_map(fn (Link $link) => $link->getUri(), $crawler->filter('main .container a.recipe-link')->links());
 
         self::assertSame([
+            'http://localhost/recipes/stockholm%20mule',
             'http://localhost/recipes/cheesecake',
             'http://localhost/recipes/ogito',
             'http://localhost/recipes/tomiritsu',
@@ -157,6 +160,9 @@ class BuildTest extends KernelTestCase
         self::assertDirectoryDoesNotExist($path);
 
         self::assertFileExists($path = $buildDir . '/recipes/ogito.pdf');
+        self::assertDirectoryDoesNotExist($path);
+
+        self::assertFileExists($path = $buildDir . '/recipes/stockholm mule.pdf');
         self::assertDirectoryDoesNotExist($path);
     }
 

--- a/tests/fixtures/app/content/recipes/stockholm mule.md
+++ b/tests/fixtures/app/content/recipes/stockholm mule.md
@@ -1,0 +1,18 @@
+---
+description: The Moscow mule alternative with spicy whisky
+title: The Stockholm Mule
+authors: ["ogi"]
+tags: ["cocktails"]
+categories: ["drink"]
+date: 2023/03/01
+tableOfContent: false
+---
+
+Learn how to make a Moscow Mule alternative with the following recipe:
+
+- 1/2 lime
+- 4cl spicy whisky (e.g: « JACK DANIEL'S Tennessee Fire 35% »)
+- 2cl amaretto
+- 2 mint leaves
+- ice
+- fill with ginger beer


### PR DESCRIPTION
so that the file path does not contains URL-encoded chars anymore, 
which would prevent serving them properly.

I have an application that includes some PDFs files rendered through a controller, where the original file might contain spaces that would be encoded in the URL (`%20`). Without this patch, the resulting file contains the encoded chars (e.g: `recipes/stockholm%20mule.pdf`). So once build statically, it cannot be served as expected. 

Bonus: 🍸 