### PR TITLE
Restore the CI pipeline

### DIFF
--- a/.github/workflows/build_static.yaml
+++ b/.github/workflows/build_static.yaml
@@ -37,7 +37,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: 'Cache composer dependencies'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: composer-${{ hashFiles('./doc/app/**/composer.lock') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,11 +88,6 @@ jobs:
             php: '8.2'
             symfony: '6.4.*'
 
-          - name: 'Test Symfony 7.0 [Linux, PHP 8.3]'
-            os: 'ubuntu-latest'
-            php: '8.3'
-            symfony: '7.0.*'
-
           # Bleeding edges:
           - name: 'Test Symfony 7.1 [Linux, PHP 8.3]'
             os: 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: 'Cache composer dependencies'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: lint-composer-${{ hashFiles('**/composer.lock') }}
@@ -127,7 +127,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: 'Cache dependencies'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}-flags-${{ matrix.composer-flags }}
@@ -181,7 +181,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: 'Cache composer dependencies'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: composer-${{ hashFiles('./doc/app/**/composer.lock') }}

--- a/tests/Integration/BuildTest.php
+++ b/tests/Integration/BuildTest.php
@@ -37,6 +37,9 @@ class BuildTest extends KernelTestCase
      */
     public function testBuildApp(): void
     {
+        // Shut down the kernel booted in setUp() before its cache is removed underneath it.
+        self::ensureKernelShutdown();
+
         // Empty build & cache
         ($fs = new Filesystem())->remove(($kernel = self::createKernel(self::$kernelOptions))->getCacheDir());
         $fs->remove($kernel->getProjectDir() . '/build');


### PR DESCRIPTION
GitHub now auto-fails workflows still using `actions/cache` v1 or v2, so the jobs stop
within seconds. Bumping to v4 gets them running again — the inputs are unchanged, so
that part is a version bump only.

With the jobs running, Symfony 7.1 then failed on 19 errors: `testBuildApp()` removes
the cache directory of the kernel `setUp()` booted, and Symfony still needs
`getServicesResetterService.php` from it on shutdown. Shutting the kernel down first
fixes it.

Symfony 7.0 is also dropped: EOL, and Composer blocks its dependencies over security
advisories.